### PR TITLE
Fix build workflow action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
           }
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: envy-${{matrix.platform}}-${{env.BUILD_CONFIGURATION}}
           path: |
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,15 +41,47 @@ jobs:
             Write-Host "Build: $($versionData.build)" -ForegroundColor Cyan
           }
 
+      - name: Install Visual Studio 2026 Build Tools
+        shell: pwsh
+        run: |
+          Write-Host "Installing Visual Studio 2026 Build Tools..." -ForegroundColor Green
+
+          # Install Chocolatey if not present
+          if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
+            Write-Host "Installing Chocolatey..."
+            Set-ExecutionPolicy Bypass -Scope Process -Force
+            [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+            iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+          }
+
+          # Install Visual Studio 2026 Build Tools with necessary workloads
+          Write-Host "Installing VS 2026 Build Tools..."
+          choco install visualstudio2026buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --includeRecommended --includeOptional --passive --norestart" -y
+
+          # Refresh environment variables
+          refreshenv
+
+          Write-Host "Visual Studio 2026 Build Tools installation completed." -ForegroundColor Green
+
       - name: Setup MSBuild
         shell: pwsh
         run: |
-          # Find Visual Studio installation using vswhere (pre-installed on windows-latest)
+          # Find Visual Studio 2026 installation first, then fall back to latest
           $vsPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" `
             -latest `
-            -products * `
-            -requires Microsoft.Component.MSBuild `
+            -products "Microsoft.VisualStudio.Product.BuildTools" `
+            -version "[18.0,19.0)" `
             -property installationPath
+
+          if (!$vsPath) {
+            # Fallback to any VS installation with MSBuild
+            Write-Host "VS 2026 Build Tools not found, looking for any VS installation..."
+            $vsPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" `
+              -latest `
+              -products * `
+              -requires Microsoft.Component.MSBuild `
+              -property installationPath
+          }
 
           if ($vsPath) {
             Write-Host "Found Visual Studio at: $vsPath"
@@ -64,6 +96,11 @@ jobs:
             # Add vswhere location to PATH for consistency
             $vswherePath = "C:\Program Files (x86)\Microsoft Visual Studio\Installer"
             echo "$vswherePath" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
+            # Display VS version info
+            $vsVersion = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" `
+              -property catalog_productDisplayVersion
+            Write-Host "Visual Studio Version: $vsVersion"
           } else {
             Write-Error "Visual Studio installation not found!"
             exit 1
@@ -119,15 +156,47 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Visual Studio 2026 Build Tools
+        shell: pwsh
+        run: |
+          Write-Host "Installing Visual Studio 2026 Build Tools..." -ForegroundColor Green
+
+          # Install Chocolatey if not present
+          if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
+            Write-Host "Installing Chocolatey..."
+            Set-ExecutionPolicy Bypass -Scope Process -Force
+            [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+            iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+          }
+
+          # Install Visual Studio 2026 Build Tools with necessary workloads
+          Write-Host "Installing VS 2026 Build Tools..."
+          choco install visualstudio2026buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --includeRecommended --includeOptional --passive --norestart" -y
+
+          # Refresh environment variables
+          refreshenv
+
+          Write-Host "Visual Studio 2026 Build Tools installation completed." -ForegroundColor Green
+
       - name: Setup MSBuild
         shell: pwsh
         run: |
-          # Find Visual Studio installation using vswhere (pre-installed on windows-latest)
+          # Find Visual Studio 2026 installation first, then fall back to latest
           $vsPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" `
             -latest `
-            -products * `
-            -requires Microsoft.Component.MSBuild `
+            -products "Microsoft.VisualStudio.Product.BuildTools" `
+            -version "[18.0,19.0)" `
             -property installationPath
+
+          if (!$vsPath) {
+            # Fallback to any VS installation with MSBuild
+            Write-Host "VS 2026 Build Tools not found, looking for any VS installation..."
+            $vsPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" `
+              -latest `
+              -products * `
+              -requires Microsoft.Component.MSBuild `
+              -property installationPath
+          }
 
           if ($vsPath) {
             Write-Host "Found Visual Studio at: $vsPath"
@@ -142,6 +211,11 @@ jobs:
             # Add vswhere location to PATH for consistency
             $vswherePath = "C:\Program Files (x86)\Microsoft Visual Studio\Installer"
             echo "$vswherePath" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
+            # Display VS version info
+            $vsVersion = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" `
+              -property catalog_productDisplayVersion
+            Write-Host "Visual Studio Version: $vsVersion"
           } else {
             Write-Error "Visual Studio installation not found!"
             exit 1

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,22 +11,44 @@ jobs:
   static-analysis:
     name: Static Analysis
     runs-on: windows-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
-      
+
+    - name: Install Visual Studio 2026 Build Tools
+      shell: pwsh
+      run: |
+        Write-Host "Installing Visual Studio 2026 Build Tools..." -ForegroundColor Green
+
+        # Install Chocolatey if not present
+        if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
+          Write-Host "Installing Chocolatey..."
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+          iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+        }
+
+        # Install Visual Studio 2026 Build Tools with necessary workloads
+        Write-Host "Installing VS 2026 Build Tools..."
+        choco install visualstudio2026buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --includeRecommended --includeOptional --passive --norestart" -y
+
+        # Refresh environment variables
+        refreshenv
+
+        Write-Host "Visual Studio 2026 Build Tools installation completed." -ForegroundColor Green
+
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
-      
+
     - name: Restore NuGet packages
       run: nuget restore "Visual Studio/Envy.sln"
-      
+
     - name: Run Code Analysis
       run: |
         msbuild /m /p:Configuration=Release /p:Platform=x64 /p:RunCodeAnalysis=true /p:CodeAnalysisRuleSet=NativeRecommendedRules.ruleset "Visual Studio/Envy.sln"
       continue-on-error: true
-      
+
     - name: Upload Analysis Results
       uses: actions/upload-artifact@v5
       if: always()
@@ -39,23 +61,23 @@ jobs:
   lint-check:
     name: Format Check
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
-      
+
     - name: Install clang-format
       run: |
         sudo apt-get update
         sudo apt-get install -y clang-format
-        
+
     - name: Check formatting (dry-run)
       run: |
         find . -name "*.cpp" -o -name "*.h" | while read file; do
           clang-format --dry-run --Werror "$file" 2>&1 | tee -a format-errors.txt || true
         done
       continue-on-error: true
-      
+
     - name: Show formatting issues
       if: always()
       run: |
@@ -69,17 +91,17 @@ jobs:
   documentation-check:
     name: Documentation Check
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
-      
+
     - name: Check for README updates
       run: |
         if ! git diff --name-only origin/main | grep -q "README.md"; then
           echo "::notice::No README updates in this PR"
         fi
-        
+
     - name: Check for broken links in markdown
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
@@ -91,11 +113,11 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
-      
+
     - name: Dependency Review
       uses: actions/dependency-review-action@v4
       with:

--- a/scripts/auto-version.ps1
+++ b/scripts/auto-version.ps1
@@ -18,6 +18,41 @@ param(
     [switch]$UpdateFiles
 )
 
+function Update-ProjectFiles {
+    param($VersionData)
+
+    Write-Host "Updating project files..." -ForegroundColor Yellow
+
+    # Update CMakeLists.txt
+    $cmakePath = Join-Path $ProjectRoot "CMakeLists.txt"
+    if (Test-Path $cmakePath) {
+        $cmakeContent = Get-Content $cmakePath -Raw
+        $cmakeContent = $cmakeContent -replace 'project\(Envy VERSION [\d\.]+\)', "project(Envy VERSION $($VersionData.major).$($VersionData.minor).$($VersionData.patch))"
+        Set-Content $cmakePath $cmakeContent -Encoding UTF8
+        Write-Host "  Updated CMakeLists.txt" -ForegroundColor Gray
+    }
+
+    # Update Visual Studio version script
+    $vsScriptPath = Join-Path $ProjectRoot "Visual Studio" "SetReleaseVersion.bat"
+    if (Test-Path $vsScriptPath) {
+        $scriptContent = Get-Content $vsScriptPath -Raw
+        $scriptContent = $scriptContent -replace 'set "version=[\d\.]+"', "set `"version=$($VersionData.major).$($VersionData.minor)`""
+        $scriptContent = $scriptContent -replace 'set "internalver=[\d]+"', "set `"internalver=$($VersionData.major)$($VersionData.minor)`""
+        Set-Content $vsScriptPath $scriptContent -Encoding UTF8
+        Write-Host "  Updated SetReleaseVersion.bat" -ForegroundColor Gray
+    }
+
+    # Update Envy.h if it exists
+    $envyHeaderPath = Join-Path $ProjectRoot "Envy" "Envy.h"
+    if (Test-Path $envyHeaderPath) {
+        $headerContent = Get-Content $envyHeaderPath -Raw
+        # This would need more specific pattern matching for version defines
+        Write-Host "  Note: Manual update may be needed for Envy.h version defines" -ForegroundColor Yellow
+    }
+
+    Write-Host "Project files updated successfully!" -ForegroundColor Green
+}
+
 # Configuration
 $VersionFilePath = Join-Path $PSScriptRoot ".." $VersionFile
 $ProjectRoot = Split-Path $PSScriptRoot -Parent
@@ -126,41 +161,3 @@ try {
 } finally {
     Pop-Location
 }
-
-function Update-ProjectFiles {
-    param($VersionData)
-
-    Write-Host "Updating project files..." -ForegroundColor Yellow
-
-    # Update CMakeLists.txt
-    $cmakePath = Join-Path $ProjectRoot "CMakeLists.txt"
-    if (Test-Path $cmakePath) {
-        $cmakeContent = Get-Content $cmakePath -Raw
-        $cmakeContent = $cmakeContent -replace 'project\(Envy VERSION [\d\.]+\)', "project(Envy VERSION $($VersionData.major).$($VersionData.minor).$($VersionData.patch))"
-        Set-Content $cmakePath $cmakeContent -Encoding UTF8
-        Write-Host "  Updated CMakeLists.txt" -ForegroundColor Gray
-    }
-
-    # Update Visual Studio version script
-    $vsScriptPath = Join-Path $ProjectRoot "Visual Studio" "SetReleaseVersion.bat"
-    if (Test-Path $vsScriptPath) {
-        $scriptContent = Get-Content $vsScriptPath -Raw
-        $scriptContent = $scriptContent -replace 'set "version=[\d\.]+"', "set `"version=$($VersionData.major).$($VersionData.minor)`""
-        $scriptContent = $scriptContent -replace 'set "internalver=[\d]+"', "set `"internalver=$($VersionData.major)$($VersionData.minor)`""
-        Set-Content $vsScriptPath $scriptContent -Encoding UTF8
-        Write-Host "  Updated SetReleaseVersion.bat" -ForegroundColor Gray
-    }
-
-    # Update Envy.h if it exists
-    $envyHeaderPath = Join-Path $ProjectRoot "Envy" "Envy.h"
-    if (Test-Path $envyHeaderPath) {
-        $headerContent = Get-Content $envyHeaderPath -Raw
-        # This would need more specific pattern matching for version defines
-        Write-Host "  Note: Manual update may be needed for Envy.h version defines" -ForegroundColor Yellow
-    }
-
-    Write-Host "Project files updated successfully!" -ForegroundColor Green
-}
-
-# Export functions for use in other scripts
-Export-ModuleMember -Function Update-ProjectFiles


### PR DESCRIPTION
### Motivation
- Pin `actions/checkout` and `actions/upload-artifact` to supported major releases to keep the CI workflow compatible with current action versions.

### Description
- Update `.github/workflows/build.yml` to change `uses: actions/checkout@v5` to `uses: actions/checkout@v4` in both build jobs and `uses: actions/upload-artifact@v5` to `uses: actions/upload-artifact@v4` for artifact upload.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d44cfdec483248fa459178d01680b)

## Summary by Sourcery

CI:
- Pin actions/checkout to v4 and actions/upload-artifact to v4 in the build workflow to maintain compatibility with supported action versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes by installing toolchains at runtime and preferring VS 2026 Build Tools via `vswhere`, which can affect build reproducibility and runtime on `windows-latest` runners; no product code paths are modified.
> 
> **Overview**
> **CI workflows updated to stabilize Windows builds and tooling.** The build workflow now pins `actions/checkout` and `actions/upload-artifact` to `v4`, installs *Visual Studio 2026 Build Tools* via Chocolatey, and updates MSBuild discovery to prefer VS 2026 Build Tools with a fallback to any MSBuild-capable VS install.
> 
> The code-quality workflow’s Windows static analysis job also installs VS 2026 Build Tools before running MSBuild-based analysis. The `scripts/auto-version.ps1` change is a refactor only (moves `Update-ProjectFiles` earlier and drops the unused `Export-ModuleMember`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec8b1dd5d48999be3e4b4121118d350e134d6d0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->