### PR TITLE
docs(deps): add dependency register, ownership map, and license skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Dependency governance docs: added `docs/DEPENDENCIES.md` (register + ownership map) and `docs/THIRD_PARTY_LICENSES.md` (vendored attribution skeleton).
 - Legacy refactor plan: `docs/10_dev/legacy-refactor-plan.md` — phased PR sequence (PR-01 → PR-26) with ready-to-paste prompts, sized for human review and aligned with `AGENTS.md` rules.
 - Documentation governance baseline: added comprehensive audit reports under `docs/audit/` (architecture, security, code quality, dependency, performance).
 - New canonical docs: `docs/ARCHITECTURE.md`, `docs/API.md`, `docs/SETUP.md`, `docs/CONTRIBUTING.md`, `docs/TESTING.md`, `docs/DEPLOYMENT.md`, and living `docs/DEVELOPMENT_PLAN.md`.

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,35 @@
+# Dependency Register
+
+This register is the living dependency inventory and ownership map for Envy's vendored native components and CI automation dependencies.
+
+| Component | Kind (vendored C/C++, Action, internal) | Source Location | Pinned Version | Upstream URL | License | Owner | Last Reviewed | Upgrade Risk | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| SQLite | vendored C/C++ | `Services/SQLite/` | 3.51.1 (`sqlite3.h`) | https://www.sqlite.org/ | Public Domain | TBD (maintainers) | 2026-05-04 | Medium | Audit marks snapshot as current/newer. |
+| zlib | vendored C/C++ | `Services/zlib/` | 1.3 (`zlib.h`) | https://zlib.net/ | zlib License | TBD (maintainers) | 2026-05-04 | Low | Audit marks baseline as current. |
+| MiniUPnPc | vendored C/C++ | `Services/MiniUPnP/` | 2.0 (header metadata, 2016) | https://miniupnp.tuxfamily.org/ | BSD-3-Clause | TBD (maintainers) | 2026-05-04 | High | Audit flags as likely outdated; NAT traversal regression risk when upgrading. |
+| UnRAR | vendored C/C++ | `Services/UnRAR/` | 5.30 (`version.hpp`, 2015 lineage) | https://www.rarlab.com/rar_add.htm | UnRAR License | TBD (maintainers) | 2026-05-04 | High | Audit flags as outdated lineage; security-sensitive extraction component. |
+| HashLib | internal | `HashLib/` | 1.0.0 (project/CMake metadata) | N/A (in-repo internal project lineage) | AGPLv3 (project headers) with mixed upstream copyright notices | TBD (maintainers) | 2026-05-04 | Medium | Internal dependency shared across core + tests. |
+| GitHub Actions (grouped) | Action | `.github/workflows/*.yml` | Pinned major tags observed (`actions/checkout@v5`, `github/codeql-action@v4`, etc.) | https://github.com/marketplace?type=actions | Per-action upstream licenses | TBD (maintainers) | 2026-05-04 | Medium | Centralized CI dependency surface; review changelogs before major bumps. |
+| Dependabot scope | Action | `.github/dependabot.yml` | GitHub Actions ecosystem only (`weekly`) | https://docs.github.com/code-security/dependabot | GitHub platform terms | TBD (maintainers) | 2026-05-04 | Medium | Native vendored C/C++ dependencies are not auto-tracked by Dependabot. |
+
+## Update Cadence & Process
+
+- **Cadence**
+  - Vendored C/C++ dependencies: **quarterly** review cadence.
+  - GitHub Actions dependencies: **monthly** review cadence.
+- **Review ownership**
+  - Primary owner remains **TBD (maintainers)** until explicit assignments are made.
+- **Validation steps before merging dependency upgrades**
+  1. Verify upstream release notes/changelog and security advisories (CVE impact).
+  2. Validate version signal in-tree (headers/version files) and update this register.
+  3. Run targeted regression checks for impacted areas (for example: NAT traversal for MiniUPnP; archive extraction safety for UnRAR; CI dry-run for Actions updates).
+  4. Update `docs/THIRD_PARTY_LICENSES.md` and `CHANGELOG.md` if license/version attribution changes.
+
+## Open Items
+
+- **MiniUPnPc (High finding #1)**
+  - Create a scoped upgrade plan from observed `2.0` baseline to current supported upstream release.
+  - Define regression checklist focused on UPnP/NAT traversal behavior and fallback paths.
+- **UnRAR (High finding #1)**
+  - Prepare staged refresh plan from `5.30` lineage, including security regression checks for extraction path validation and archive parsing behavior.
+  - Confirm license obligations and re-validate in-tree attribution during upgrade PR.

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -4,13 +4,13 @@ This register is the living dependency inventory and ownership map for Envy's ve
 
 | Component | Kind (vendored C/C++, Action, internal) | Source Location | Pinned Version | Upstream URL | License | Owner | Last Reviewed | Upgrade Risk | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| SQLite | vendored C/C++ | `Services/SQLite/` | 3.51.1 (`sqlite3.h`) | https://www.sqlite.org/ | Public Domain | TBD (maintainers) | 2026-05-04 | Medium | Audit marks snapshot as current/newer. |
-| zlib | vendored C/C++ | `Services/zlib/` | 1.3 (`zlib.h`) | https://zlib.net/ | zlib License | TBD (maintainers) | 2026-05-04 | Low | Audit marks baseline as current. |
-| MiniUPnPc | vendored C/C++ | `Services/MiniUPnP/` | 2.0 (header metadata, 2016) | https://miniupnp.tuxfamily.org/ | BSD-3-Clause | TBD (maintainers) | 2026-05-04 | High | Audit flags as likely outdated; NAT traversal regression risk when upgrading. |
-| UnRAR | vendored C/C++ | `Services/UnRAR/` | 5.30 (`version.hpp`, 2015 lineage) | https://www.rarlab.com/rar_add.htm | UnRAR License | TBD (maintainers) | 2026-05-04 | High | Audit flags as outdated lineage; security-sensitive extraction component. |
-| HashLib | internal | `HashLib/` | 1.0.0 (project/CMake metadata) | N/A (in-repo internal project lineage) | AGPLv3 (project headers) with mixed upstream copyright notices | TBD (maintainers) | 2026-05-04 | Medium | Internal dependency shared across core + tests. |
-| GitHub Actions (grouped) | Action | `.github/workflows/*.yml` | Pinned major tags observed (`actions/checkout@v5`, `github/codeql-action@v4`, etc.) | https://github.com/marketplace?type=actions | Per-action upstream licenses | TBD (maintainers) | 2026-05-04 | Medium | Centralized CI dependency surface; review changelogs before major bumps. |
-| Dependabot scope | Action | `.github/dependabot.yml` | GitHub Actions ecosystem only (`weekly`) | https://docs.github.com/code-security/dependabot | GitHub platform terms | TBD (maintainers) | 2026-05-04 | Medium | Native vendored C/C++ dependencies are not auto-tracked by Dependabot. |
+| SQLite | vendored C/C++ | `Services/SQLite/` | 3.51.1 (`sqlite3.h`) | https://www.sqlite.org/ | Public Domain | @Mika3578 | 2026-05-04 | Medium | Audit marks snapshot as current/newer. |
+| zlib | vendored C/C++ | `Services/zlib/` | **Version drift:** `zlib.h` reports 1.3; `Version.txt` and `zlib.rc` still say 1.2.10. | https://zlib.net/ | zlib License | @Mika3578 | 2026-05-04 | Low | Conflicting in-tree version signals; Version.txt/zlib.rc not yet updated to match header. |
+| MiniUPnPc | vendored C/C++ | `Services/MiniUPnP/` | 2.0 (header metadata, 2016) | https://miniupnp.tuxfamily.org/ | BSD-3-Clause | @Mika3578 | 2026-05-04 | High | Audit flags as likely outdated; NAT traversal regression risk when upgrading. |
+| UnRAR | vendored C/C++ | `Services/UnRAR/` | **Version drift:** `version.hpp`/`dll.rc` report 5.30; `Version.txt` says 5.3.8 (Nov.2015 lineage). | https://www.rarlab.com/rar_add.htm | UnRAR License | @Mika3578 | 2026-05-04 | High | Conflicting in-tree version signals; audit flags as outdated; security-sensitive extraction component. |
+| HashLib | internal | `HashLib/` | 1.0.0 (project/CMake metadata) | N/A (in-repo internal project lineage) | GPLv3-or-later (project headers) with mixed upstream copyright notices | @Mika3578 | 2026-05-04 | Medium | Internal dependency shared across core + tests. |
+| GitHub Actions (grouped) | Action | `.github/workflows/*.yml` | Moving major tags (`actions/checkout@v5`, `github/codeql-action@v4`, etc.) — not immutable pins | https://github.com/marketplace?type=actions | Per-action upstream licenses | @Mika3578 | 2026-05-04 | Medium | Not pinned to SHA; review changelogs before major bumps. |
+| Dependabot scope | Action | `.github/dependabot.yml` | GitHub Actions ecosystem only (`weekly`) | https://docs.github.com/code-security/dependabot | GitHub platform terms | @Mika3578 | 2026-05-04 | Medium | Native vendored C/C++ dependencies are not auto-tracked by Dependabot. |
 
 ## Update Cadence & Process
 
@@ -18,7 +18,7 @@ This register is the living dependency inventory and ownership map for Envy's ve
   - Vendored C/C++ dependencies: **quarterly** review cadence.
   - GitHub Actions dependencies: **monthly** review cadence.
 - **Review ownership**
-  - Primary owner remains **TBD (maintainers)** until explicit assignments are made.
+  - Primary owner: **@Mika3578** (repository maintainer). Update this field when additional co-maintainers are assigned.
 - **Validation steps before merging dependency upgrades**
   1. Verify upstream release notes/changelog and security advisories (CVE impact).
   2. Validate version signal in-tree (headers/version files) and update this register.

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -66,5 +66,5 @@
 ## Open Questions
 1. Should this project explicitly remain Windows-only, or is cross-platform parity still a target?
 2. What is the acceptable backward-compatibility policy for legacy protocols/features?
-3. Which dependency update cadence (monthly/quarterly) is realistic for maintainers?
+3. ~~Which dependency update cadence (monthly/quarterly) is realistic for maintainers?~~ **Resolved 2026-05-04:** Quarterly for vendored C/C++; monthly for GitHub Actions (see Decisions Log).
 4. Should remote API documentation be strict contract-first or implementation-first?

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -2,7 +2,8 @@
 
 > **LIVING DOCUMENT** — Must be updated after every meaningful change (feature, architectural decision, scope change, blocker resolution).
 
-- **Last Updated:** 2026-04-22
+- **Last Updated:** 2026-05-04
+- **Changelog Entry:** 2026-05-04 — Completed Phase 1 dependency register + ownership map and recorded maintenance cadence.
 - **Changelog Entry:** 2026-04-22 — Initial comprehensive planning baseline established during documentation and audit pass.
 
 ## Update Protocol
@@ -34,7 +35,7 @@
 ## Roadmap
 
 ### Phase 1 — Stability & Visibility (P0)
-- [ ] Create dependency register + ownership map (2d)
+- [x] Create dependency register + ownership map (2d)
 - [ ] Add threat model and secure-coding checklist (2d)
 - [ ] Expand tests for protocol parser/state-machine paths (5d)
 - [ ] Establish baseline metrics (startup, memory, throughput) (3d)
@@ -57,6 +58,7 @@
 - Archive legacy `.vcproj` files once migration is complete
 
 ## Decisions Log
+- **2026-05-04:** Set dependency review cadence to quarterly for vendored C/C++ libraries and monthly for GitHub Actions dependencies.
 - **2026-04-22:** Keep Visual Studio solution as authoritative full-build path while CMake remains partial.
 - **2026-04-22:** Standardize new audit reports under `docs/audit/`.
 - **2026-04-22:** Treat this plan as a required living artifact for project management continuity.

--- a/docs/THIRD_PARTY_LICENSES.md
+++ b/docs/THIRD_PARTY_LICENSES.md
@@ -5,7 +5,7 @@ This document tracks bundled third-party attribution for vendored components. En
 | Component | Declared License | In-Tree License Evidence |
 |---|---|---|
 | SQLite | Public Domain | `Services/SQLite/sqlite3.h` header notice (public domain statement). |
-| zlib | zlib License | TODO: explicit standalone license file not found under `Services/zlib/`; verify and add canonical license text file/link. |
+| zlib | zlib License | `Services/zlib/zlibwapi.txt` (full license notice) and `Services/zlib/zlib.h` header notice. |
 | MiniUPnPc | BSD-3-Clause | `Services/MiniUPnP/License.txt`. |
 | UnRAR | UnRAR License | `Services/UnRAR/License.txt`. |
-| HashLib | AGPLv3 (per file headers) with mixed upstream notices | TODO: no dedicated `HashLib` license file found; current evidence is per-source header blocks (for example `HashLib/HashLib.h`, `HashLib/MD5.cpp`, `HashLib/SHA.cpp`). |
+| HashLib | GPLv3-or-later (per file headers) with mixed upstream notices | No dedicated `HashLib` license file; evidence is per-source header blocks (for example `HashLib/HashLib.h`, `HashLib/MD5.cpp`, `HashLib/SHA.cpp`). TODO: add a standalone `HashLib/LICENSE` file. |

--- a/docs/THIRD_PARTY_LICENSES.md
+++ b/docs/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,11 @@
+# Third-Party Licenses (Vendored Components)
+
+This document tracks bundled third-party attribution for vendored components. Entries marked `TODO` require maintainer follow-up to confirm or add explicit in-tree license text.
+
+| Component | Declared License | In-Tree License Evidence |
+|---|---|---|
+| SQLite | Public Domain | `Services/SQLite/sqlite3.h` header notice (public domain statement). |
+| zlib | zlib License | TODO: explicit standalone license file not found under `Services/zlib/`; verify and add canonical license text file/link. |
+| MiniUPnPc | BSD-3-Clause | `Services/MiniUPnP/License.txt`. |
+| UnRAR | UnRAR License | `Services/UnRAR/License.txt`. |
+| HashLib | AGPLv3 (per file headers) with mixed upstream notices | TODO: no dedicated `HashLib` license file found; current evidence is per-source header blocks (for example `HashLib/HashLib.h`, `HashLib/MD5.cpp`, `HashLib/SHA.cpp`). |

--- a/docs/audit/DEPENDENCY_AUDIT.md
+++ b/docs/audit/DEPENDENCY_AUDIT.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-04-22
 - **Scope:** In-repo vendored libraries, GitHub Actions dependencies, language/runtime dependencies
 - **Method:** Static version macro inspection and workflow review
+- **Dependency Register:** See the living register at [`docs/DEPENDENCIES.md`](../DEPENDENCIES.md).
 
 ## Dependency Inventory (Observed)
 


### PR DESCRIPTION
### Motivation
- Provide a single living dependency register and ownership map to address audit findings about outdated vendored libraries and the lack of a centralized manifest. 
- Improve visibility of bundled license obligations by adding a third-party attribution skeleton. 
- Record a concrete update cadence decision to reduce future drift and clarify reviewer responsibilities. 

### Description
- Added `docs/DEPENDENCIES.md` containing a table (7 rows: SQLite, zlib, MiniUPnPc, UnRAR, HashLib, grouped GitHub Actions, Dependabot scope) with columns `Component | Kind | Source Location | Pinned Version | Upstream URL | License | Owner | Last Reviewed | Upgrade Risk | Notes` and an `Update Cadence & Process` section proposing quarterly vendored reviews and monthly Actions reviews. 
- Added `docs/THIRD_PARTY_LICENSES.md` with one entry per vendored component and explicit `TODO` flags where in-tree license text is missing (zlib, HashLib). 
- Updated `docs/DEVELOPMENT_PLAN.md` to mark the Phase 1 task complete, bump `Last Updated` to `2026-05-04`, add the one-line changelog per the update protocol, and record the dependency cadence decision in the `Decisions Log`. 
- Updated `docs/audit/DEPENDENCY_AUDIT.md` to cross-link to the new living register and added a single `CHANGELOG.md` `[Unreleased] -> Added` bullet referencing the new docs. 

### Testing
- Ran an automated relative-markdown-link existence check over changed docs (`python` script) and it passed (`OK`). 
- Performed repository inspection to confirm vendored components and in-tree license evidence (found `Services/SQLite/sqlite3.h`, `Services/zlib/zlib.h`/`Version.txt`, `Services/MiniUPnP/License.txt`, `Services/UnRAR/License.txt`, and header attributions in `HashLib/`), and recorded `TODO` entries where evidence was incomplete. 
- No build or runtime changes were introduced as this is documentation-only work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b1e626d48324a0f9a231be567cf4)