### PR TITLE
Document develop branch hygiene and dependency register status in DEVELOPMENT_PLAN and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated `docs/DEVELOPMENT_PLAN.md` to reflect current `develop` repository hygiene status, including branch posture (`develop` default, `main` behind), CI gate maturity guidance, and Dependabot label prerequisites (`ci`, `dependencies`).
 - Clarified dependency register status as **not complete** while `docs/DEPENDENCIES.md` is absent on `develop`.
+- Rewrote root `README.md` to reflect current repository layout, build entry points, and documentation map.
+- Updated `.github/PULL_REQUEST_TEMPLATE.md` to align with risk-based review and validation reporting.
+- **Full protocol comparison audit** - Comprehensive comparison against reference implementations (eMule, aMule, libtorrent, qBittorrent, Transmission)
+  - Updated `docs/10_dev/status.md` with detailed feature matrices for all protocol areas
+  - Updated `docs/10_dev/roadmap.md` with evidence-based phases and accurate TODO items
 
 
 ### Security
@@ -25,13 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New canonical docs: `docs/ARCHITECTURE.md`, `docs/API.md`, `docs/SETUP.md`, `docs/CONTRIBUTING.md`, `docs/TESTING.md`, `docs/DEPLOYMENT.md`, and living `docs/DEVELOPMENT_PLAN.md`.
 - GitHub community/automation configuration: Markdown issue templates, `security.yml` (secret scanning), `CODEOWNERS`, and Dependabot configuration for GitHub Actions.
 - Agent guidance files: root `CLAUDE.md`, root `AGENTS.md`, and refreshed `.cursor/rules/README.md`.
-
-### Changed
-- Rewrote root `README.md` to reflect current repository layout, build entry points, and documentation map.
-- Updated `.github/PULL_REQUEST_TEMPLATE.md` to align with risk-based review and validation reporting.
-- **Full protocol comparison audit** - Comprehensive comparison against reference implementations (eMule, aMule, libtorrent, qBittorrent, Transmission)
-  - Updated `docs/10_dev/status.md` with detailed feature matrices for all protocol areas
-  - Updated `docs/10_dev/roadmap.md` with evidence-based phases and accurate TODO items
 
 ### Added
 - **ED2K SecureID version fix** - Changed `ED2K_VERSION_SECUREID` from 0 to 3 in `EDPacket.h`; peers now correctly see Envy as supporting SecureID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated `docs/DEVELOPMENT_PLAN.md` to reflect current `develop` repository hygiene status, including branch posture (`develop` default, `main` behind), CI gate maturity guidance, and Dependabot label prerequisites (`ci`, `dependencies`).
+- Clarified dependency register status as **not complete** while `docs/DEPENDENCIES.md` is absent on `develop`.
+
 
 ### Security
 - Remote UI hardening completed for CRITICAL/HIGH audit findings: cryptographically secure CSRF tokens, centralized token handling, DOMPurify-backed sanitization for dynamic HTML, redirect allowlist enforcement, and boundary API input validation with typed errors.

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -2,8 +2,8 @@
 
 > **LIVING DOCUMENT** — Must be updated after every meaningful change (feature, architectural decision, scope change, blocker resolution).
 
-- **Last Updated:** 2026-04-22
-- **Changelog Entry:** 2026-04-22 — Added IPv6 dual-stack Phase 0 scope/plan docs (`docs/ipv6/SCOPE.md`, `docs/ipv6/PLAN.md`); Remote CRITICAL/HIGH security findings remediated; JS regression suite and CI gate added.
+- **Last Updated:** 2026-05-15
+- **Changelog Entry:** 2026-05-15 — Synced repository hygiene status for `develop`: documented branch state, CI gate maturity, Dependabot labels requirement, and dependency register status (not complete because `docs/DEPENDENCIES.md` is absent).
 
 ## Update Protocol
 1. Update **Last Updated** date on every meaningful change.
@@ -11,6 +11,13 @@
 3. Reflect status changes in **Current Status** and **Roadmap**.
 4. Record consequential technical decisions in **Decisions Log**.
 5. Close or refresh **Open Questions** explicitly.
+
+
+## Repository Status (develop)
+- Default branch is `develop`.
+- `main` is currently behind `develop`.
+- CI workflows exist, but should not yet be treated as mandatory merge gates until required checks are consistently emitted and stable in GitHub Actions.
+- Dependabot expects GitHub labels `ci` and `dependencies` to exist for automated PR labeling.
 
 ## Vision & Goals
 - Maintain Envy as a stable multi-network P2P client for Windows.
@@ -36,7 +43,7 @@
 ## Roadmap
 
 ### Phase 1 — Stability & Visibility (P0)
-- [ ] Create dependency register + ownership map (2d)
+- [ ] Create dependency register + ownership map (2d) — **Not complete on develop** (`docs/DEPENDENCIES.md` is currently missing).
 - [x] Add threat model and secure-coding checklist (2d)
 - [ ] Expand tests for protocol parser/state-machine paths (5d)
 - [ ] Establish baseline metrics (startup, memory, throughput) (3d)
@@ -59,6 +66,7 @@
 - Archive legacy `.vcproj` files once migration is complete
 
 ## Decisions Log
+- **2026-05-15:** Repository hygiene baseline on `develop` requires explicit branch-state tracking and GitHub label prerequisites (`ci`, `dependencies`) before enforcing CI as mandatory gates.
 - **2026-04-22:** Added IPv6 dual-stack Phase 0 scoping inventory and phased rollout plan under `docs/ipv6/`.
 - **2026-04-22:** Remote web UI must use cryptographic token generation (`crypto.getRandomValues`) and allowlist-based redirect validation for all client-side navigation paths.
 - **2026-04-22:** Keep Visual Studio solution as authoritative full-build path while CMake remains partial.


### PR DESCRIPTION
### Motivation
- Record the current repository hygiene and branch posture for `develop` so maintainers have accurate operational guidance.
- Clarify CI gate maturity and Dependabot labeling prerequisites to avoid prematurely enforcing checks.
- Surface that the dependency register is not present on `develop` by marking `docs/DEPENDENCIES.md` as missing.

### Description
- Updated `docs/DEVELOPMENT_PLAN.md` to set `Last Updated` to `2026-05-15`, add a changelog entry, and add a `Repository Status (develop)` section describing that the default branch is `develop`, `main` is behind, CI gates are not yet mandatory, and Dependabot expects `ci` and `dependencies` labels.
- Modified the roadmap in `docs/DEVELOPMENT_PLAN.md` to mark the dependency register task as `Not complete on develop` and added a `2026-05-15` Decisions Log entry recording branch-state and label prerequisites before enforcing CI gates.
- Updated `CHANGELOG.md` under `Unreleased` to include a `Changed` entry summarizing the `docs/DEVELOPMENT_PLAN.md` sync and the dependency register status.

### Testing
- No automated tests were executed because this is a documentation-only change and does not affect code or runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076485ebfc8324a10f20b3e776e7fd)