### PR TITLE
protocol(ed2k): harden and modernize source exchange handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Hardened ED2K/eMule Source Exchange parsing (`OP_ANSWERSOURCES`/`OP_ANSWERSOURCES2`) with shared defensive source-count/body-length validation to reject malformed packet bodies safely.
+- Modernized SourceEx2 request parsing to defensively handle 32-bit vs legacy large-file size encodings while preserving existing wire compatibility and peer behavior.
+- Updated `EDClient.h` capability annotation for `m_bEmSupportsSourceEx2` to match the implemented/advertised behavior.
+- Added interoperability notes at `docs/30_protocols/ed2k/SOURCE_EXCHANGE_INTEROP_NOTES.md`, including explicit IPv6 limitation documentation (current SourceEx paths are IPv4-only on-wire).
 - Updated `docs/DEVELOPMENT_PLAN.md` to reflect current `develop` repository hygiene status, including branch posture (`develop` default, `main` behind), CI gate maturity guidance, and Dependabot label prerequisites (`ci`, `dependencies`).
 - Clarified dependency register status as **not complete** while `docs/DEPENDENCIES.md` is absent on `develop`.
 - Rewrote root `README.md` to reflect current repository layout, build entry points, and documentation map.

--- a/Envy/EDClient.cpp
+++ b/Envy/EDClient.cpp
@@ -3129,8 +3129,8 @@ BOOL CEDClient::OnSourceAnswer(CEDPacket* pPacket)
 
 //////////////////////////////////////////////////////////////////////
 // CEDClient source request v2 (SourceEx2)
-// Format: <HASH 16><FileSizeLow 4>[FileSizeHigh 4 (legacy, detected heuristically when Low==0)]<Options 2>
-// Note: The legacy large-file form is wire-ambiguous with a 32-bit zero size and inherited from eMule behavior.
+// Format: <HASH 16><FileSizeLow 4>[FileSizeHigh 4 (legacy, detected heuristically when Low==0 and >=6 bytes remain)]<Options 2>
+// Note: This eMule-inherited wire format is ambiguous for a 32-bit zero size; parser resolves by packet length heuristic.
 
 BOOL CEDClient::OnSourceRequest2(CEDPacket* pPacket)
 {

--- a/Envy/EDClient.cpp
+++ b/Envy/EDClient.cpp
@@ -3156,8 +3156,7 @@ BOOL CEDClient::OnSourceRequest2(CEDPacket* pPacket)
 		return TRUE;
 	}
 
-	WORD nOptions = pPacket->ReadShortLE();
-	UNREFERENCED_PARAMETER( nOptions );
+	(void)pPacket->ReadShortLE();
 
 	CEDPacket* pReply = CEDPacket::New( ED2K_C2C_ANSWERSOURCES2, ED2K_PROTOCOL_EMULE );
 	int nCount = 0;

--- a/Envy/EDClient.cpp
+++ b/Envy/EDClient.cpp
@@ -3013,6 +3013,17 @@ BOOL CEDClient::OnPreviewAnswer(CEDPacket* pPacket)
 	return TRUE;
 }
 
+static BOOL ValidateSourcePacketBody(CEDPacket* pPacket, DWORD nCount, DWORD nSourceSize)
+{
+	if ( nSourceSize == 0 ) return FALSE;
+
+	const DWORD nRemaining = pPacket->GetRemaining();
+	if ( nCount > ( nRemaining / nSourceSize ) )
+		return FALSE;
+
+	return nRemaining >= nCount * nSourceSize;
+}
+
 //////////////////////////////////////////////////////////////////////
 // CEDClient source request
 
@@ -3088,7 +3099,8 @@ BOOL CEDClient::OnSourceAnswer(CEDPacket* pPacket)
 	pPacket->Read( oHash );
 	DWORD nCount = pPacket->ReadShortLE();
 
-	if ( pPacket->GetRemaining() < nCount * ( ( m_bEmSources >= 2 ) ? 12u + 16u : 12u ) )
+	const DWORD nSourceSize = ( m_bEmSources >= 2 ) ? 28u : 12u;
+	if ( ! ValidateSourcePacketBody( pPacket, nCount, nSourceSize ) )
 	{
 		theApp.Message( MSG_ERROR, IDS_ED2K_CLIENT_BAD_PACKET, (LPCTSTR)m_sAddress, pPacket->m_nType );
 		return TRUE;
@@ -3131,16 +3143,21 @@ BOOL CEDClient::OnSourceRequest2(CEDPacket* pPacket)
 	pPacket->Read( oHash );
 
 	DWORD nFileSizeLow = pPacket->ReadLongLE();
-	QWORD nFileSize = nFileSizeLow;
 
-	// If the low 32 bits indicate a large file and there's more data, read the high 32 bits
-	if ( nFileSizeLow == 0 && pPacket->GetRemaining() >= 4 + 2 )
+	// SourceEx2 request file size can be 32-bit, or 64-bit in legacy large-file format (<0><high32>).
+	if ( nFileSizeLow == 0 && pPacket->GetRemaining() >= 6 )
 	{
-		DWORD nFileSizeHigh = pPacket->ReadLongLE();
-		nFileSize = ( (QWORD)nFileSizeHigh << 32 ) | nFileSizeLow;
+		(void)pPacket->ReadLongLE();
+	}
+
+	if ( pPacket->GetRemaining() < 2 )
+	{
+		theApp.Message( MSG_ERROR, IDS_ED2K_CLIENT_BAD_PACKET, (LPCTSTR)m_sAddress, pPacket->m_nType );
+		return TRUE;
 	}
 
 	WORD nOptions = pPacket->ReadShortLE();
+	UNREFERENCED_PARAMETER( nOptions );
 
 	CEDPacket* pReply = CEDPacket::New( ED2K_C2C_ANSWERSOURCES2, ED2K_PROTOCOL_EMULE );
 	int nCount = 0;
@@ -3202,7 +3219,7 @@ BOOL CEDClient::OnSourceAnswer2(CEDPacket* pPacket)
 
 	// SourceEx2 always includes GUID (28 bytes per source)
 	const DWORD nSourceSize = 4 + 2 + 4 + 2 + 16;
-	if ( pPacket->GetRemaining() < nCount * nSourceSize )
+	if ( ! ValidateSourcePacketBody( pPacket, nCount, nSourceSize ) )
 	{
 		theApp.Message( MSG_ERROR, IDS_ED2K_CLIENT_BAD_PACKET, (LPCTSTR)m_sAddress, pPacket->m_nType );
 		return TRUE;

--- a/Envy/EDClient.cpp
+++ b/Envy/EDClient.cpp
@@ -3129,7 +3129,8 @@ BOOL CEDClient::OnSourceAnswer(CEDPacket* pPacket)
 
 //////////////////////////////////////////////////////////////////////
 // CEDClient source request v2 (SourceEx2)
-// Format: <HASH 16><FileSize 4 or 8><Options 2>
+// Format: <HASH 16><FileSizeLow 4>[FileSizeHigh 4 (legacy, detected heuristically when Low==0)]<Options 2>
+// Note: The legacy large-file form is wire-ambiguous with a 32-bit zero size and inherited from eMule behavior.
 
 BOOL CEDClient::OnSourceRequest2(CEDPacket* pPacket)
 {

--- a/Envy/EDClient.cpp
+++ b/Envy/EDClient.cpp
@@ -3145,7 +3145,9 @@ BOOL CEDClient::OnSourceRequest2(CEDPacket* pPacket)
 
 	DWORD nFileSizeLow = pPacket->ReadLongLE();
 
-	// SourceEx2 request file size can be 32-bit, or 64-bit in legacy large-file format (<0><high32>).
+	// SourceEx2 request file size can be 32-bit, or legacy 64-bit format (<0><high32>).
+	// Legacy form is detected heuristically (Low32 == 0 and enough bytes for <high32><Options>),
+	// which is an on-wire ambiguity inherited from eMule.
 	if ( nFileSizeLow == 0 && pPacket->GetRemaining() >= 6 )
 	{
 		(void)pPacket->ReadLongLE();

--- a/Envy/EDClient.h
+++ b/Envy/EDClient.h
@@ -88,7 +88,7 @@ public:
 
 // Client capabilities 2
 	BOOL		m_bEmSupportsCaptcha;
-	BOOL		m_bEmSupportsSourceEx2;		// Not supported
+	BOOL		m_bEmSupportsSourceEx2;		// Source Exchange v2 support
 	BOOL		m_bEmRequiresCryptLayer;	// Not supported
 	BOOL		m_bEmRequestsCryptLayer;	// Not supported
 	BOOL		m_bEmSupportsCryptLayer;	// Not supported

--- a/docs/30_protocols/ed2k/SOURCE_EXCHANGE_INTEROP_NOTES.md
+++ b/docs/30_protocols/ed2k/SOURCE_EXCHANGE_INTEROP_NOTES.md
@@ -1,0 +1,18 @@
+# ED2K/eMule Source Exchange Interoperability Notes
+
+## Scope
+This note documents current Envy behavior for Source Exchange v1/v2 packets and pragmatic compatibility expectations with eMule/aMule style peers.
+
+## Packet Compatibility
+- `OP_REQUESTSOURCES` (0x81) and `OP_ANSWERSOURCES` (0x82) remain supported and unchanged on-wire.
+- `OP_REQUESTSOURCES2` (0x83) and `OP_ANSWERSOURCES2` (0x84) remain supported and preferred when peer capability negotiation reports SourceEx2 support (`nOpt2` bit 10).
+- Source list entries remain serialized in legacy IPv4 shape: `<ClientID 4><Port 2><ServerIP 4><ServerPort 2>[GUID 16]`.
+
+## Defensive Parsing
+- Source answer handlers now validate list body length against count and per-entry size before reading any source tuples.
+- Malformed or truncated source packets are rejected through existing bad-packet handling/logging path.
+
+## Current Limitation (Explicit)
+- SourceEx and SourceEx2 source tuples are currently IPv4-only on-wire in Envy.
+- No IPv6 source tuple encoding/decoding is currently implemented for Source Exchange packets.
+- This is intentional for compatibility with the existing legacy ED2K/eMule tuple format and to avoid wire-format regressions in this incremental hardening pass.

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -6,6 +6,8 @@
 - **Changelog Entry:** 2026-05-15 — Synced repository hygiene status for `develop`: documented branch state, CI gate maturity, Dependabot labels requirement, and dependency register status (not complete because `docs/DEPENDENCIES.md` is absent).
 - **Changelog Entry:** 2026-05-15 — Hardened legacy Kad publish packet construction by replacing unsafe keyword copy with bounded copy and explicit terminator in `KadProtocol::CreatePublishRequest`, preserving wire format.
 
+- **Changelog Entry:** 2026-05-15 — ED2K Source Exchange hardening: added shared bounds validation for SourceEx/SourceEx2 source lists, modernized SourceEx2 request length handling, and documented current IPv4-only SourceEx wire limitation.
+
 ## Update Protocol
 1. Update **Last Updated** date on every meaningful change.
 2. Add a one-line entry to the changelog section above.


### PR DESCRIPTION
### Motivation
- Reduce malformed-packet and boundary risks in ED2K Source Exchange parsing while preserving on-wire compatibility with eMule/aMule peers. 
- Incrementally modernize SourceEx2 request parsing (32-bit vs legacy 64-bit large-file form) without changing protocol negotiation or tuple serialization. 
- Make the code comment for SourceEx2 capability accurate and document current IPv4-only limitations to avoid future regressions.

### Description
- Added a shared defensive validator `ValidateSourcePacketBody(CEDPacket*, DWORD nCount, DWORD nSourceSize)` and applied it to `CEDClient::OnSourceAnswer()` and `CEDClient::OnSourceAnswer2()` to pre-check remaining packet bytes against the declared `nCount` and per-source size before reading tuples (file: `Envy/EDClient.cpp`).
- Modernized `CEDClient::OnSourceRequest2()` parsing to defensively handle the legacy large-file encoding (`<0><high32>`) by skipping the extra dword only when present and rejecting packets that are truncated before the `Options` field; preserved existing wire semantics for peers that send either 32-bit or legacy 64-bit forms (file: `Envy/EDClient.cpp`).
- Kept IPv4 tuple serialization unchanged (wire-compatible `<ClientID 4><Port 2><ServerIP 4><ServerPort 2>[GUID 16]`) and explicitly documented the current lack of IPv6 source-tuple support in an interoperability note (new file: `docs/30_protocols/ed2k/SOURCE_EXCHANGE_INTEROP_NOTES.md`).
- Corrected capability comment for `m_bEmSupportsSourceEx2` in `Envy/EDClient.h` to reflect implemented/advertised behavior, and updated repository docs (`CHANGELOG.md`, `docs/DEVELOPMENT_PLAN.md`) with the change summary.

### Testing
- Ran repository validation checks: `git diff --check` completed with no trailing-whitespace errors. 
- Verified working-tree changes with `git status --short` and searched for modified symbols with `rg` to confirm the intended edits (`ValidateSourcePacketBody`, `OnSourceAnswer2`, `OnSourceRequest2`, `m_bEmSupportsSourceEx2`, `SOURCE_EXCHANGE_INTEROP_NOTES`).
- No new unit tests were added because this change is a small, incremental hardening around existing parse paths; behavior-preserving tests (wire compatibility) were validated by code inspection and targeted static checks only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077f73ebd48324b4a4393e006fa7f0)