### PR TITLE
Fix CodeQL cpp/type-confusion alerts in XML, EDPacket and UploadQueue (#2663,#2662,#2661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Security
+- Fixed CodeQL `cpp/type-confusion` alerts (#2663, #2662, #2661) by replacing unsafe downcasts with checked polymorphic/RTTI-safe handling in XML deletion, ED2K file tagging, and ED2K upload start paths without changing protocol or ownership semantics.
 - Kad publish packet builder now uses bounded keyword copying in `KadProtocol::CreatePublishRequest` (`memcpy` + explicit null terminator) and added null/size guards for `buffer`, `targetId`, and `keyword` before writes, preserving existing packet wire format and 255-byte keyword limit.
 - Remote UI hardening completed for CRITICAL/HIGH audit findings: cryptographically secure CSRF tokens, centralized token handling, DOMPurify-backed sanitization for dynamic HTML, redirect allowlist enforcement, and boundary API input validation with typed errors.
 - CSP tightened for modern Remote pages by removing `'unsafe-inline'` and migrating inline handlers/styles/scripts to external assets (`modern-page-handlers.js`, `modern-inline.css`).

--- a/Envy/EDPacket.cpp
+++ b/Envy/EDPacket.cpp
@@ -250,8 +250,9 @@ void CEDPacket::WriteFile(const CEnvyFile* pEnvyFile, QWORD nSize,
 {
 	ASSERT( ( pClient && ! pServer ) || ( ! pClient && pServer ) );
 
-	const CLibraryFile* pFile = bPartial ?
-		NULL : static_cast< const CLibraryFile* >( pEnvyFile );
+	const CLibraryFile* pFile = NULL;
+	if ( ! bPartial )
+		pFile = dynamic_cast< const CLibraryFile* >( pEnvyFile );
 
 	bool bDeflate = ( pServer && ( pServer->m_nTCPFlags & ED2K_SERVER_TCP_DEFLATE ) != 0 );
 	bool bUnicode = ( pServer && ( pServer->m_nTCPFlags & ED2K_SERVER_TCP_UNICODE ) != 0 ) ||

--- a/Envy/UploadQueue.cpp
+++ b/Envy/UploadQueue.cpp
@@ -1,7 +1,7 @@
 //
 // UploadQueue.cpp
 //
-// This file is part of Envy (getenvy.com)  2016-2018
+// This file is part of Envy (getenvy.com) Â 2016-2018
 // Portions copyright Shareaza 2002-2008 and PeerProject 2008-2014
 //
 // Envy is free software. You may redistribute and/or modify it
@@ -329,8 +329,10 @@ void CUploadQueue::StartImpl(CUploadTransfer* pUpload)
 	pUpload->m_pQueue = this;
 	if ( pUpload->m_nProtocol == PROTOCOL_ED2K )
 	{
-		CUploadTransferED2K * pEdUpload = static_cast<CUploadTransferED2K *>(pUpload);
-		pEdUpload->m_pClient->Connect();
+		CUploadTransferED2K* pEdUpload = dynamic_cast< CUploadTransferED2K* >( pUpload );
+		ASSERT( pEdUpload != NULL );
+		if ( pEdUpload != NULL && pEdUpload->m_pClient != NULL )
+			pEdUpload->m_pClient->Connect();
 	}
 }
 

--- a/Envy/UploadQueue.cpp
+++ b/Envy/UploadQueue.cpp
@@ -1,7 +1,7 @@
 //
 // UploadQueue.cpp
 //
-// This file is part of Envy (getenvy.com)  2016-2018
+// This file is part of Envy (getenvy.com) © 2016-2018
 // Portions copyright Shareaza 2002-2008 and PeerProject 2008-2014
 //
 // Envy is free software. You may redistribute and/or modify it

--- a/Envy/XML.cpp
+++ b/Envy/XML.cpp
@@ -1,7 +1,7 @@
 //
 // XML.cpp
 //
-// This file is part of Envy (getenvy.com) © 2016-2018
+// This file is part of Envy (getenvy.com) Â© 2016-2018
 // Portions copyright Shareaza 2002-2008 and PeerProject 2008-2016
 //
 // Envy is free software. You may redistribute and/or modify it
@@ -45,18 +45,15 @@ CXMLNode::~CXMLNode()
 {
 }
 
+void CXMLNode::RemoveFromParent()
+{
+}
+
 void CXMLNode::Delete()
 {
 	if ( this == NULL ) return;
 
-	if ( m_pParent != NULL )
-	{
-		if ( m_nNode == xmlElement )
-			m_pParent->RemoveElement( (CXMLElement*)this );
-		else if ( m_nNode == xmlAttribute )
-			m_pParent->RemoveAttribute( (CXMLAttribute*)this );
-	}
-
+	RemoveFromParent();
 	delete this;
 }
 
@@ -180,6 +177,12 @@ CXMLElement::CXMLElement(CXMLElement* pParent, LPCTSTR pszName) : CXMLNode( pPar
 {
 	m_nNode = xmlElement;
 	m_bOrdered = TRUE;		// Retain Attribute inserton order (workaround)
+}
+
+void CXMLElement::RemoveFromParent()
+{
+	if ( m_pParent != NULL )
+		m_pParent->RemoveElement( this );
 }
 
 CXMLElement::~CXMLElement()
@@ -820,6 +823,12 @@ LPCTSTR CXMLAttribute::schemaName		= L"xsi:noNamespaceSchemaLocation";
 CXMLAttribute::CXMLAttribute(CXMLElement* pParent, LPCTSTR pszName) : CXMLNode( pParent, pszName )
 {
 	m_nNode = xmlAttribute;
+}
+
+void CXMLAttribute::RemoveFromParent()
+{
+	if ( m_pParent != NULL )
+		m_pParent->RemoveAttribute( this );
 }
 
 CXMLAttribute::~CXMLAttribute()

--- a/Envy/XML.h
+++ b/Envy/XML.h
@@ -46,7 +46,7 @@ protected:
 	void			Serialize(CArchive& ar);
 
 public:
-	virtual void	Delete();
+	void			Delete();
 	virtual void	RemoveFromParent();
 	int				GetType() const;
 	CXMLNode*		AsNode() const;

--- a/Envy/XML.h
+++ b/Envy/XML.h
@@ -84,7 +84,7 @@ protected:
 	void			ToString(CString& strXML, BOOL bNewline) const;
 
 public:
-	virtual void	RemoveFromParent();
+	void			RemoveFromParent() override;
 	CXMLElement*	Detach();
 	CXMLElement*	Clone(CXMLElement* pParent = NULL) const;
 	CXMLElement*	Prefix(const CString& sPrefix, CXMLElement* pParent = NULL) const;		// Clone element then rename all elements and attributes by using specified prefix

--- a/Envy/XML.h
+++ b/Envy/XML.h
@@ -1,7 +1,7 @@
 //
 // XML.h
 //
-// This file is part of Envy (getenvy.com) © 2016-2018
+// This file is part of Envy (getenvy.com) Â© 2016-2018
 // Portions copyright Shareaza 2002-2008 and PeerProject 2008-2015
 //
 // Envy is free software. You may redistribute and/or modify it
@@ -46,7 +46,8 @@ protected:
 	void			Serialize(CArchive& ar);
 
 public:
-	void			Delete();
+	virtual void	Delete();
+	virtual void	RemoveFromParent();
 	int				GetType() const;
 	CXMLNode*		AsNode() const;
 	CXMLElement*	AsElement() const;
@@ -83,6 +84,7 @@ protected:
 	void			ToString(CString& strXML, BOOL bNewline) const;
 
 public:
+	virtual void	RemoveFromParent();
 	CXMLElement*	Detach();
 	CXMLElement*	Clone(CXMLElement* pParent = NULL) const;
 	CXMLElement*	Prefix(const CString& sPrefix, CXMLElement* pParent = NULL) const;		// Clone element then rename all elements and attributes by using specified prefix
@@ -129,6 +131,8 @@ public:
 	virtual ~CXMLAttribute();
 
 public:
+	virtual void	RemoveFromParent();
+
 	static LPCTSTR	xmlnsSchema;
 	static LPCTSTR	xmlnsInstance;
 	static LPCTSTR	schemaName;


### PR DESCRIPTION
### Motivation
- Address CodeQL `cpp/type-confusion` alerts `#2663` (`Envy/XML.cpp` around `CXMLNode::Delete`), `#2662` (`Envy/EDPacket.cpp` around `CEDPacket::WriteFile`) and `#2661` (`Envy/UploadQueue.cpp` around `CUploadQueue::StartImpl`) by removing unsafe unchecked downcasts that can produce type confusion at runtime. 
- The common root cause was unchecked downcasting from base pointers to derived types (C-style or `static_cast`) based solely on control-flow/state assumptions instead of runtime verification, allowing mismatches between compile-time assumptions and actual object types.
- Changes must be minimal and preserve existing runtime, protocol, serialization, and ownership semantics while eliminating the unsafe casts.

### Description
- Reworked XML deletion to add a virtual helper `RemoveFromParent()` on `CXMLNode` (default no-op) and overrides in `CXMLElement` and `CXMLAttribute` that call `m_pParent->RemoveElement(this)` and `m_pParent->RemoveAttribute(this)` respectively, and changed `CXMLNode::Delete()` to call `RemoveFromParent()` before `delete this`, removing unsafe C-style downcasts in `CXMLNode::Delete`. 
- Hardened `CEDPacket::WriteFile` by replacing `static_cast<const CLibraryFile*>` with a checked `dynamic_cast<const CLibraryFile*>`, keeping `pFile == NULL` when the cast fails so CLibraryFile-only metadata is skipped while preserving ED2K packet output for valid `CLibraryFile` inputs. 
- Hardened `CUploadQueue::StartImpl` by replacing `static_cast<CUploadTransferED2K*>` with `dynamic_cast<CUploadTransferED2K*>`, adding `ASSERT(pEdUpload != NULL)`, and guarding the `Connect()` call with `pEdUpload != NULL && pEdUpload->m_pClient != NULL` to avoid invoking ED2K-specific code on the wrong type without changing queue ordering or state transitions. 
- Added a concise `[Unreleased] / Security` entry to `CHANGELOG.md` documenting alerts `#2663`, `#2662`, and `#2661` and the nature of the fix.

### Testing
- Ran `git diff --check` which completed without reported whitespace or index errors. 
- Attempted builds for Windows targets but the environment lacks the build toolchain, and `msbuild` was not available (`msbuild: command not found`), so `Debug/Release x86` and `Debug/Release x64` builds could not be executed here. 
- Attempted to re-run CodeQL in this environment but the CLI was not available (`codeql: command not found`), so CodeQL scan and automated alert closure verification were not performed here. 
- Please run CI/Windows validation (the four platform builds) and a CodeQL scan to confirm alerts `#2663`, `#2662`, and `#2661` are closed and that no new Critical/High alerts are introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07960d7a7c83248eb7bac2d4061e14)