### PR TITLE
ci(codeql): improve csharp analysis quality with manual build

### DIFF
--- a/.github/workflows/codeql-csharp.yml
+++ b/.github/workflows/codeql-csharp.yml
@@ -1,0 +1,54 @@
+name: "CodeQL C# Manual Build"
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-csharp-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-csharp:
+    name: Analyze (csharp)
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+
+      - name: Initialize CodeQL (manual C# build)
+        uses: github/codeql-action/init@v4
+        with:
+          languages: csharp
+          build-mode: manual
+          queries: security-extended,security-and-quality
+
+      - name: Build SkinUpdater solution (Release, Any CPU)
+        shell: cmd
+        run: |
+          msbuild "Languages\Tools\SkinUpdater\SkinUpdater.sln" ^
+            /m ^
+            /nologo ^
+            /verbosity:minimal ^
+            /p:Configuration=Release ^
+            /p:Platform="Any CPU"
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:csharp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,8 +30,6 @@ jobs:
         include:
           - language: c-cpp
             build-mode: manual
-          - language: csharp
-            build-mode: none
           - language: javascript-typescript
             build-mode: none
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **CodeQL C# analysis quality** — Split C# CodeQL into dedicated manual-build workflow (`.github/workflows/codeql-csharp.yml`) on `windows-latest` with `security-extended` and `security-and-quality` queries, and removed C# `build-mode: none` from the shared CodeQL matrix.
 - **Build / CI (Phase 0, PR #35)** — Rebased modernization branch onto `develop`; CI uses `windows-2025-vs2026` with strict `v145` enforcement, path-filtered workflows, and MSBuild log artifacts. Fixed additional C++20 compile blockers (`TOOLBAR_RES`, `TCPBandwidthMeter`, legacy `std::binary_function` functors).
 - Added operational documentation governance set: `docs/DEV_TRACKER.md`, `docs/PR_PLAYBOOK.md`, `docs/DECISIONS.md`, `docs/KNOWN_LIMITATIONS.md`, `docs/LABELS.md`, `docs/DEPENDENCIES.md`, and `docs/audit/REPOSITORY_CLEANUP_AUDIT.md`.
 - Clarified canonical doc split (strategic vs operational vs deep protocol reference) and improved root documentation discoverability in `README.md`.

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -2,7 +2,8 @@
 
 > **LIVING DOCUMENT** — Must be updated after every meaningful change (feature, architectural decision, scope change, blocker resolution).
 
-- **Last Updated:** 2026-05-15
+- **Last Updated:** 2026-05-17
+- **Changelog Entry:** 2026-05-17 — Improved CodeQL C# analysis precision by introducing a dedicated manual-build workflow and documenting legacy FictionBookReader build blockers plus minimal .NET Framework 4.8 retarget path.
 - **Changelog Entry:** 2026-05-15 — Synced repository hygiene status for `develop`: documented branch state, CI gate maturity, Dependabot labels requirement, and dependency register status (`docs/DEPENDENCIES.md` exists but remains an incomplete seed).
 - **Changelog Entry:** 2026-05-15 — Hardened legacy Kad publish packet construction by replacing unsafe keyword copy with bounded copy and explicit terminator in `KadProtocol::CreatePublishRequest`, preserving wire format.
 

--- a/docs/DEV_TRACKER.md
+++ b/docs/DEV_TRACKER.md
@@ -38,6 +38,7 @@ This is the **operational dashboard** for day-to-day execution.
 - **Phase 0 / PR #35** — Visual Studio 2026 (`v145`) toolset migration, hosted CI on `windows-2025-vs2026`, build-log artifacts, AI rules (target base: `develop`).
 - Consolidating duplicated status/tracker information into this operational dashboard.
 - CI signal quality improvements and clearer required-vs-advisory checks.
+- CodeQL C# analysis quality hardening: moved from `build-mode: none` to dedicated manual-build workflow and documented legacy C# blockers.
 - Dependency ownership visibility and risk classification.
 
 ### Next
@@ -84,6 +85,7 @@ This is the **operational dashboard** for day-to-day execution.
 
 | Check | Last known result (pre-rebase push) | Notes |
 |---|---|---|
+| CodeQL C# manual build | **Updated** | Dedicated `.github/workflows/codeql-csharp.yml` now uses manual build for `SkinUpdater`; legacy FictionBookReader blockers documented in `docs/maintenance/codeql-csharp.md`. |
 | Lint build files | PASS | No legacy `v141_xp` / `v142` outside `Plugins/PluginWizard` |
 | Format check (`clang-format`) | PASS | |
 | clang-tidy (advisory) | PASS | |

--- a/docs/maintenance/codeql-csharp.md
+++ b/docs/maintenance/codeql-csharp.md
@@ -1,0 +1,64 @@
+# CodeQL C# manual-build status
+
+## Why this exists
+
+GitHub CodeQL reported low C# analysis quality because C# extraction was
+running with `build-mode: none`, which reduces call-target resolution.
+
+This repository now uses a dedicated workflow at
+`.github/workflows/codeql-csharp.yml` with:
+
+- `github/codeql-action/init@v4`
+- `languages: csharp`
+- `build-mode: manual`
+- `queries: security-extended,security-and-quality`
+- explicit `msbuild` compilation for C# solutions that currently build
+
+## C# solutions/projects inventory
+
+Detected C# artifacts in this repository:
+
+- `Languages/Tools/SkinUpdater/SkinUpdater.sln`
+- `Languages/Tools/SkinUpdater/SkinUpdater.csproj`
+- `Languages/Tools/SkinUpdater/Common/UpdaterCommon.csproj`
+- `Plugins/FictionBookReader/FictionBookReader.sln`
+- `Plugins/FictionBookReader/FictionBookReader.csproj`
+- `Plugins/NETInterop/FictionBookReader/FictionBookReader.VS2008.sln`
+- `Plugins/NETInterop/FictionBookReader/FictionBookReader.csproj`
+
+## Buildability on modern hosted runners
+
+### Build succeeds (included in manual CodeQL build)
+
+- `Languages/Tools/SkinUpdater/SkinUpdater.sln`
+  - Built successfully with MSBuild Release / Any CPU.
+  - Produces `SkinUpdater.Common.dll` and `SkinUpdater.exe`.
+
+### Build currently blocked (not silently ignored)
+
+- `Plugins/FictionBookReader/FictionBookReader.sln`
+- `Plugins/NETInterop/FictionBookReader/FictionBookReader.VS2008.sln`
+  - Solution-level build currently fails to parse in modern MSBuild
+    (`MSB4025: Root element is missing`).
+  - First remediation step is solution-file normalization (header/BOM,
+    leading blank-line cleanup, and consistent line endings), then retry
+    with modern MSBuild before project retargeting.
+
+- `Plugins/FictionBookReader/FictionBookReader.csproj`
+- `Plugins/NETInterop/FictionBookReader/FictionBookReader.csproj`
+  - Project-level build fails with missing .NET Framework targeting pack:
+    `MSB3644: reference assemblies for .NETFramework,Version=v4.0 were not found`.
+
+## Smallest modernization path (behavior-preserving)
+
+After solution parsing is fixed, for both `FictionBookReader.csproj`
+variants:
+
+1. Retarget to `.NET Framework 4.8` in project metadata.
+2. Keep `ToolsVersion` upgrade minimal (SDK-style migration not required).
+3. Keep existing compile items, pre/post-build scripts, and COM interop
+   flow unchanged unless build requires a narrowly scoped adjustment.
+4. Rebuild under CI with the same manual CodeQL workflow after retargeting.
+
+This path is intentionally minimal and focuses on buildability for CodeQL
+precision, not runtime feature changes.


### PR DESCRIPTION
## Summary
- Replace C# CodeQL `build-mode: none` with a dedicated manual-build workflow in `.github/workflows/codeql-csharp.yml` using `github/codeql-action/init@v4`, `microsoft/setup-msbuild@v2`, and `security-extended,security-and-quality` queries.
- Build `Languages/Tools/SkinUpdater/SkinUpdater.sln` explicitly so C# extraction is based on compiled code paths and improves call-target resolution precision.
- Remove C# from the shared `.github/workflows/codeql.yml` matrix and document FictionBookReader legacy blockers plus a minimal behavior-preserving modernization sequence in `docs/maintenance/codeql-csharp.md`.

## Test plan
- [x] Build `Languages/Tools/SkinUpdater/SkinUpdater.sln` locally with MSBuild (`Release|Any CPU`) to confirm manual-build candidate succeeds.
- [x] Attempt builds for `Plugins/FictionBookReader/FictionBookReader.sln` and `Plugins/NETInterop/FictionBookReader/FictionBookReader.VS2008.sln`; confirmed parse blocker (`MSB4025`) and documented remediation-first normalization path.
- [x] Attempt direct project builds for both FictionBookReader `.csproj` files; confirmed missing .NET Framework v4.0 targeting pack (`MSB3644`) and documented next retarget step to .NET Framework 4.8 after solution normalization.
- [ ] Let GitHub Actions run `CodeQL C# Manual Build` on this PR and verify C# analysis quality warning is reduced/cleared.

Made with [Cursor](https://cursor.com)