### PR TITLE
test(ed2k): protocol parser smoke tests for Source Exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,6 +304,7 @@ Doxyfile.bak
 ###############################################################################
 
 # vcpkg
+vcpkg/
 vcpkg_installed/
 vcpkg_manifests/
 
@@ -428,4 +429,3 @@ Plugins/SkinScan/SkinScan.h
 Plugins/VirusTotal/VirusTotal.h
 Plugins/WindowsThumbnail/WindowsThumbnail.h
 Plugins/ZIPBuilder/ZIPBuilder.h
-vcpkg/

--- a/Envy/EDClient.cpp
+++ b/Envy/EDClient.cpp
@@ -22,6 +22,7 @@
 #include "EDClient.h"
 #include "EDClients.h"
 #include "EDPacket.h"
+#include "EDSourcePacketValidate.h"
 #include "EDNeighbour.h"
 #include "FileIdentifier.h"
 #include "Neighbours.h"
@@ -3015,13 +3016,7 @@ BOOL CEDClient::OnPreviewAnswer(CEDPacket* pPacket)
 
 static BOOL ValidateSourcePacketBody(CEDPacket* pPacket, DWORD nCount, DWORD nSourceSize)
 {
-	if ( nSourceSize == 0 ) return FALSE;
-
-	const DWORD nRemaining = pPacket->GetRemaining();
-	if ( nCount > ( nRemaining / nSourceSize ) )
-		return FALSE;
-
-	return nRemaining >= nCount * nSourceSize;
+	return Ed2kValidateSourcePacketBody( pPacket->GetRemaining(), nCount, nSourceSize );
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3134,7 +3129,7 @@ BOOL CEDClient::OnSourceAnswer(CEDPacket* pPacket)
 
 BOOL CEDClient::OnSourceRequest2(CEDPacket* pPacket)
 {
-	if ( pPacket->GetRemaining() < Hashes::Ed2kHash::byteCount + 4 + 2 )
+	if ( pPacket->GetRemaining() < Ed2kSourceEx2RequestMinBytes() )
 	{
 		theApp.Message( MSG_ERROR, IDS_ED2K_CLIENT_BAD_PACKET, (LPCTSTR)m_sAddress, pPacket->m_nType );
 		return TRUE;
@@ -3148,12 +3143,10 @@ BOOL CEDClient::OnSourceRequest2(CEDPacket* pPacket)
 	// SourceEx2 request file size can be 32-bit, or legacy 64-bit format (<0><high32>).
 	// Legacy form is detected heuristically (Low32 == 0 and enough bytes for <high32><Options>),
 	// which is an on-wire ambiguity inherited from eMule.
-	if ( nFileSizeLow == 0 && pPacket->GetRemaining() >= 6 )
-	{
+	if ( const DWORD nLegacy = Ed2kSourceEx2ConsumeLegacyHigh32( nFileSizeLow, pPacket->GetRemaining() ) )
 		(void)pPacket->ReadLongLE();
-	}
 
-	if ( pPacket->GetRemaining() < 2 )
+	if ( ! Ed2kSourceEx2HasOptionsBytes( pPacket->GetRemaining() ) )
 	{
 		theApp.Message( MSG_ERROR, IDS_ED2K_CLIENT_BAD_PACKET, (LPCTSTR)m_sAddress, pPacket->m_nType );
 		return TRUE;
@@ -3209,7 +3202,7 @@ BOOL CEDClient::OnSourceAnswer2(CEDPacket* pPacket)
 {
 	if ( ! Settings.Library.SourceMesh ) return TRUE;
 
-	if ( pPacket->GetRemaining() < Hashes::Ed2kHash::byteCount + 2 )
+	if ( pPacket->GetRemaining() < Ed2kSourceEx2AnswerMinBytes() )
 	{
 		theApp.Message( MSG_ERROR, IDS_ED2K_CLIENT_BAD_PACKET, (LPCTSTR)m_sAddress, pPacket->m_nType );
 		return TRUE;
@@ -3220,7 +3213,7 @@ BOOL CEDClient::OnSourceAnswer2(CEDPacket* pPacket)
 	DWORD nCount = pPacket->ReadShortLE();
 
 	// SourceEx2 always includes GUID (28 bytes per source)
-	const DWORD nSourceSize = 4 + 2 + 4 + 2 + 16;
+	const DWORD nSourceSize = Ed2kSourceEx2SourceRecordBytes();
 	if ( ! ValidateSourcePacketBody( pPacket, nCount, nSourceSize ) )
 	{
 		theApp.Message( MSG_ERROR, IDS_ED2K_CLIENT_BAD_PACKET, (LPCTSTR)m_sAddress, pPacket->m_nType );

--- a/Envy/EDSourcePacketValidate.h
+++ b/Envy/EDSourcePacketValidate.h
@@ -1,0 +1,64 @@
+//
+// EDSourcePacketValidate.h
+//
+// Pure ED2K Source Exchange packet-boundary checks (no network / MFC).
+// Shared by EDClient handlers and EnvyTests smoke tests.
+//
+// This file is part of Envy (getenvy.com) (C) 2016-2026
+//
+
+#pragma once
+
+#include <windows.h>
+
+// Declared source count vs bytes remaining (SourceEx v1/v2 answer bodies).
+inline BOOL Ed2kValidateSourcePacketBody(DWORD nRemaining, DWORD nCount, DWORD nSourceSize)
+{
+	if ( nSourceSize == 0 )
+		return FALSE;
+
+	if ( nCount > ( nRemaining / nSourceSize ) )
+		return FALSE;
+
+	return nRemaining >= nCount * nSourceSize;
+}
+
+// <HASH 16><FileSizeLow 4><Options 2> minimum before optional legacy high32.
+inline constexpr DWORD Ed2kSourceEx2RequestMinBytes()
+{
+	return 16u + 4u + 2u;
+}
+
+// <HASH 16><Count 2> minimum before source records.
+inline constexpr DWORD Ed2kSourceEx2AnswerMinBytes()
+{
+	return 16u + 2u;
+}
+
+// Per-source record size in SourceEx2 answers (IPv4 + GUID).
+inline constexpr DWORD Ed2kSourceEx2SourceRecordBytes()
+{
+	return 4u + 2u + 4u + 2u + 16u;
+}
+
+// Legacy 64-bit size encoding: optional high32 dword when Low32==0 and room remains.
+inline DWORD Ed2kSourceEx2LegacyHigh32Bytes(DWORD nFileSizeLow, DWORD nRemainingAfterLow)
+{
+	// eMule-inherited ambiguity: Low32==0 may introduce a legacy high32 before Options.
+	if ( nFileSizeLow == 0 && nRemainingAfterLow >= 6 )
+		return 4;
+
+	return 0;
+}
+
+// Backward-compatible wrapper for existing call sites.
+inline DWORD Ed2kSourceEx2ConsumeLegacyHigh32(DWORD nFileSizeLow, DWORD nRemainingAfterLow)
+{
+	return Ed2kSourceEx2LegacyHigh32Bytes( nFileSizeLow, nRemainingAfterLow );
+}
+
+// Options ushort must still be present after size fields.
+inline BOOL Ed2kSourceEx2HasOptionsBytes(DWORD nRemainingAfterSizeFields)
+{
+	return nRemainingAfterSizeFields >= 2;
+}

--- a/Envy/Envy.vcxproj
+++ b/Envy/Envy.vcxproj
@@ -1294,6 +1294,7 @@ if exist "$(SolutionDir)Data\Vendors.xml" copy /Y "$(SolutionDir)Data\Vendors.xm
     <ClInclude Include="EDClients.h" />
     <ClInclude Include="EDNeighbour.h" />
     <ClInclude Include="EDPacket.h" />
+    <ClInclude Include="EDSourcePacketValidate.h" />
     <ClInclude Include="EDPartImporter.h" />
     <ClInclude Include="Emoticons.h" />
     <ClInclude Include="FileExecutor.h" />

--- a/tests/EnvyTests.vcxproj
+++ b/tests/EnvyTests.vcxproj
@@ -77,7 +77,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\HashLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\HashLib;$(ProjectDir)..\Envy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;WIN32;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -102,7 +102,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\HashLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\HashLib;$(ProjectDir)..\Envy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;WIN64;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -128,7 +128,7 @@
     <ClCompile>
       <Optimization>Full</Optimization>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\HashLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\HashLib;$(ProjectDir)..\Envy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;WIN32;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -153,7 +153,7 @@
     <ClCompile>
       <Optimization>Full</Optimization>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\HashLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\HashLib;$(ProjectDir)..\Envy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;WIN64;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -177,6 +177,7 @@
   <ItemGroup>
     <ClCompile Include="test_main.cpp" />
     <ClCompile Include="test_hashlib.cpp" />
+    <ClCompile Include="test_protocol_parser_smoke.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="test_framework.h" />

--- a/tests/EnvyTests.vcxproj.filters
+++ b/tests/EnvyTests.vcxproj.filters
@@ -17,6 +17,9 @@
     <ClCompile Include="test_hashlib.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="test_protocol_parser_smoke.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="test_framework.h">

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -12,11 +12,13 @@
 
 // Test modules register their tests via these functions
 void register_hashlib_tests(TestSuite& suite);
+void register_protocol_parser_smoke_tests(TestSuite& suite);
 
 int main() {
 	TestSuite suite;
 
 	register_hashlib_tests(suite);
+	register_protocol_parser_smoke_tests(suite);
 
 	int failures = suite.run_all_tests();
 

--- a/tests/test_protocol_parser_smoke.cpp
+++ b/tests/test_protocol_parser_smoke.cpp
@@ -1,0 +1,103 @@
+//
+// test_protocol_parser_smoke.cpp
+//
+// In-memory smoke tests for ED2K Source Exchange packet boundary checks.
+// No live network; exercises EDSourcePacketValidate only.
+//
+// This file is part of Envy (getenvy.com) (C) 2016-2026
+//
+
+#include "test_framework.h"
+#include "../Envy/EDSourcePacketValidate.h"
+
+static bool test_source_body_valid_exact()
+{
+	const DWORD nSourceSize = Ed2kSourceEx2SourceRecordBytes();
+	const DWORD nCount = 2;
+	const DWORD nRemaining = nCount * nSourceSize;
+	return Ed2kValidateSourcePacketBody( nRemaining, nCount, nSourceSize ) == TRUE;
+}
+
+static bool test_source_body_valid_empty()
+{
+	const DWORD nSourceSize = Ed2kSourceEx2SourceRecordBytes();
+	return Ed2kValidateSourcePacketBody( 0, 0, nSourceSize ) == TRUE;
+}
+
+static bool test_source_body_truncated()
+{
+	const DWORD nSourceSize = Ed2kSourceEx2SourceRecordBytes();
+	return Ed2kValidateSourcePacketBody( nSourceSize, 2, nSourceSize ) == FALSE;
+}
+
+static bool test_source_body_count_overflow()
+{
+	const DWORD nSourceSize = 12u;
+	return Ed2kValidateSourcePacketBody( 100, 20, nSourceSize ) == FALSE;
+}
+
+static bool test_source_body_zero_record_size()
+{
+	return Ed2kValidateSourcePacketBody( 100, 1, 0 ) == FALSE;
+}
+
+static bool test_source_ex2_request_min_header()
+{
+	return Ed2kSourceEx2RequestMinBytes() == 22u;
+}
+
+static bool test_source_ex2_answer_min_header()
+{
+	return Ed2kSourceEx2AnswerMinBytes() == 18u;
+}
+
+static bool test_source_ex2_legacy_high32_consumed()
+{
+	const DWORD nRemainingAfterLow = 6;
+	return Ed2kSourceEx2LegacyHigh32Bytes( 0, nRemainingAfterLow ) == 4u;
+}
+
+static bool test_source_ex2_legacy_high32_skipped_short()
+{
+	return Ed2kSourceEx2LegacyHigh32Bytes( 0, 5 ) == 0u;
+}
+
+static bool test_source_ex2_legacy_high32_skipped_nonzero_low()
+{
+	return Ed2kSourceEx2LegacyHigh32Bytes( 1024, 10 ) == 0u;
+}
+
+static bool test_source_ex2_options_tail_present()
+{
+	const DWORD nRemaining = 4 + 2;
+	const DWORD nLegacy = Ed2kSourceEx2LegacyHigh32Bytes( 0, 6 );
+	return Ed2kSourceEx2HasOptionsBytes( nRemaining - nLegacy ) == TRUE;
+}
+
+static bool test_source_ex2_options_tail_missing()
+{
+	return Ed2kSourceEx2HasOptionsBytes( 1 ) == FALSE;
+}
+
+static bool test_source_ex2_answer_malformed_count()
+{
+	const DWORD nSourceSize = Ed2kSourceEx2SourceRecordBytes();
+	return Ed2kValidateSourcePacketBody( nSourceSize - 1, 1, nSourceSize ) == FALSE;
+}
+
+void register_protocol_parser_smoke_tests(TestSuite& suite)
+{
+	suite.add_test( "ed2k_source_body_exact_fit", test_source_body_valid_exact );
+	suite.add_test( "ed2k_source_body_empty", test_source_body_valid_empty );
+	suite.add_test( "ed2k_source_body_truncated", test_source_body_truncated );
+	suite.add_test( "ed2k_source_body_count_overflow", test_source_body_count_overflow );
+	suite.add_test( "ed2k_source_body_zero_record", test_source_body_zero_record_size );
+	suite.add_test( "ed2k_source_ex2_request_min_header", test_source_ex2_request_min_header );
+	suite.add_test( "ed2k_source_ex2_answer_min_header", test_source_ex2_answer_min_header );
+	suite.add_test( "ed2k_source_ex2_legacy_high32", test_source_ex2_legacy_high32_consumed );
+	suite.add_test( "ed2k_source_ex2_legacy_skip_short", test_source_ex2_legacy_high32_skipped_short );
+	suite.add_test( "ed2k_source_ex2_legacy_skip_nonzero", test_source_ex2_legacy_high32_skipped_nonzero_low );
+	suite.add_test( "ed2k_source_ex2_options_present", test_source_ex2_options_tail_present );
+	suite.add_test( "ed2k_source_ex2_options_missing", test_source_ex2_options_tail_missing );
+	suite.add_test( "ed2k_source_ex2_answer_truncated", test_source_ex2_answer_malformed_count );
+}


### PR DESCRIPTION
## Summary
- Extract ED2K Source Exchange packet-boundary helpers into `Envy/EDSourcePacketValidate.h`.
- Add 12 in-memory smoke tests in `tests/test_protocol_parser_smoke.cpp` (EnvyTests).
- Document coverage in CHANGELOG, docs/TESTING.md, DEV_TRACKER.md.

**Blocker:** CEDClient/CEDPacket handlers are not linked in EnvyTests (full MFC app required); tests use the extracted validation seam only.

## Test plan
- [x] git diff --check
- [x] MSBuild EnvyTests Release x64 v145
- [x] EnvyTests.exe 25/25 passed
- [ ] Full Envy Release build (not run)
