### PR TITLE
ci: reduce PR check warnings on hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: x64
 
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload build logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: build-logs-${{ matrix.platform }}-${{ matrix.configuration }}
           path: |
@@ -269,7 +269,7 @@ jobs:
 
       - name: Upload binaries
         if: success() && matrix.configuration == 'Release'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: envy-${{ matrix.platform }}-${{ matrix.configuration }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload build logs
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: build-logs-${{ matrix.platform }}-${{ matrix.configuration }}
           path: |
@@ -269,7 +269,7 @@ jobs:
 
       - name: Upload binaries
         if: success() && matrix.configuration == 'Release'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: envy-${{ matrix.platform }}-${{ matrix.configuration }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,22 +1,24 @@
 name: Build
 
+# checkov:skip=CKV_GHA_7:Manual reruns need an operator-selected configuration.
 on:
   push:
-    branches: [main, develop, "claude/**"]
+    branches: [main, develop, claude/**]
     paths-ignore:
+      # yamllint disable-line rule:quoted-strings -- ** must be quoted (YAML alias)
       - "**.md"
-      - "Languages/**"
-      - "Templates/**"
-      - "Skins/**"
-      - "Data/**"
+      - Languages/**
+      - Templates/**
+      - Skins/**
+      - Data/**
   pull_request:
     branches: [main, develop]
   workflow_dispatch:
     inputs:
       configuration:
-        description: "Build configuration"
+        description: Build configuration
         required: true
-        default: "Release"
+        default: Release
         type: choice
         options: [Release, Debug]
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: clang-tidy-report
           path: clang-tidy.log

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: clang-tidy-report
           path: clang-tidy.log

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     branches: [main, develop]
     paths:
-      - "Envy/**.cpp"
-      - "Envy/**.h"
-      - "TorrentEnvy/**.cpp"
-      - "TorrentEnvy/**.h"
-      - "HashLib/**.cpp"
-      - "HashLib/**.h"
-      - ".clang-tidy"
-      - ".github/workflows/clang-tidy.yml"
+      - Envy/**.cpp
+      - Envy/**.h
+      - TorrentEnvy/**.cpp
+      - TorrentEnvy/**.h
+      - HashLib/**.cpp
+      - HashLib/**.h
+      - .clang-tidy
+      - .github/workflows/clang-tidy.yml
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,7 +9,7 @@ on:
 
 # Third-party JS actions (markdown link check, dependency-review) lack Node 24 builds.
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   static-analysis:
@@ -41,7 +41,7 @@ jobs:
       continue-on-error: true
       
     - name: Upload Analysis Results
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: code-analysis-results
@@ -103,8 +103,10 @@ jobs:
           echo "No files changed in this pull request; skipping README advisory."
           exit 0
         fi
-        if ! echo "$changed" | grep -qx 'README.md'; then
-          echo "::notice::No README updates in this PR"
+        if echo "$changed" | grep -qE '^(Envy|Services|Plugins|HashLib|TorrentEnvy|Remote)/'; then
+          if ! echo "$changed" | grep -Fxq 'README.md'; then
+            echo "::notice::No README updates in this PR"
+          fi
         fi
         
     - name: Check for broken links in markdown

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,10 +7,14 @@ on:
     branches: [ main, master, develop ]
   workflow_dispatch:
 
+# Third-party JS actions (markdown link check, dependency-review) lack Node 24 builds.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   static-analysis:
     name: Static Analysis
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     
     steps:
     - name: Checkout code
@@ -26,7 +30,7 @@ jobs:
         Write-Host "VS 2026 Build Tools installation completed"
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
       
     - name: Restore NuGet packages
       run: nuget restore "Visual Studio/Envy.sln"
@@ -82,10 +86,24 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
-      
+      with:
+        fetch-depth: 0
+
     - name: Check for README updates
+      if: github.event_name == 'pull_request'
       run: |
-        if ! git diff --name-only origin/main | grep -q "README.md"; then
+        base="${{ github.event.pull_request.base.sha }}"
+        head="${{ github.event.pull_request.head.sha }}"
+        if [ -z "$base" ] || [ -z "$head" ]; then
+          echo "Missing PR SHAs; skipping README advisory."
+          exit 0
+        fi
+        changed=$(git diff --name-only "$base...$head" || true)
+        if [ -z "$changed" ]; then
+          echo "No files changed in this pull request; skipping README advisory."
+          exit 0
+        fi
+        if ! echo "$changed" | grep -qx 'README.md'; then
           echo "::notice::No README updates in this PR"
         fi
         
@@ -108,7 +126,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
         cache: npm
         cache-dependency-path: Remote/tests/package-lock.json
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main, master, develop ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Third-party JS actions (markdown link check, dependency-review) lack Node 24 builds.
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/codeql-csharp.yml
+++ b/.github/workflows/codeql-csharp.yml
@@ -1,4 +1,4 @@
-name: "CodeQL C# Manual Build"
+name: CodeQL C# Manual Build
 
 on:
   push:
@@ -54,4 +54,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:csharp"
+          category: /language:csharp

--- a/.github/workflows/codeql-csharp.yml
+++ b/.github/workflows/codeql-csharp.yml
@@ -16,18 +16,21 @@ concurrency:
   group: codeql-csharp-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analyze-csharp:
     name: Analyze (csharp)
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     timeout-minutes: 60
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: x64
 

--- a/.github/workflows/codeql-csharp.yml
+++ b/.github/workflows/codeql-csharp.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   analyze-csharp:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ concurrency:
   group: codeql-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -46,7 +49,7 @@ jobs:
 
       - name: Add MSBuild to PATH
         if: matrix.language == 'c-cpp'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: x64
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: "CodeQL Advanced"
+name: CodeQL Advanced
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main, develop]
   schedule:
     # Weekly scan on Sunday early morning UTC
-    - cron: "13 4 * * 0"
+    - cron: 13 4 * * 0
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   analyze:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: recursive
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Bootstrap vcpkg
         shell: pwsh

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   auto-merge:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   auto-merge:
     name: Auto-merge safe Dependabot PRs

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,9 @@ concurrency:
   group: dep-review-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   review:
     name: Dependency review

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   review:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ permissions:
 
 # actions/labeler@v6 has no Node 24 release yet; opt in until upstream ships one.
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   label:
@@ -22,7 +22,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          COUNT=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq 'length')
+          COUNT=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate | jq -s 'map(.[]) | length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then
             echo "No files changed in this pull request; labeler will be skipped."

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,12 +8,28 @@ permissions:
   contents: read
   pull-requests: write
 
+# actions/labeler@v6 has no Node 24 release yet; opt in until upstream ships one.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   label:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Detect changed files
+        id: changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COUNT=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq 'length')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" = "0" ]; then
+            echo "No files changed in this pull request; labeler will be skipped."
+          fi
+
       - uses: actions/labeler@v6
+        if: steps.changes.outputs.count != '0'
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
   contents: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   build:
@@ -71,7 +71,7 @@ jobs:
             | Copy-Item -Destination artifacts -Force
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: envy-${{ matrix.platform }}-release
           path: artifacts/**
@@ -85,7 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v6
         with:
           path: dist
           pattern: envy-*-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,13 @@
 name: Release
 
+# checkov:skip=CKV_GHA_7:Release tag is operator-supplied for manual publishes.
 on:
   push:
-    tags: ["v*"]
+    tags: [v*]
   workflow_dispatch:
     inputs:
       version:
-        description: "Release tag (e.g. v5.0.0)"
+        description: Release tag (e.g. v5.0.0)
         required: true
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build Release ${{ matrix.platform }}
@@ -29,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: x64
 
@@ -68,7 +71,7 @@ jobs:
             | Copy-Item -Destination artifacts -Force
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: envy-${{ matrix.platform }}-release
           path: artifacts/**
@@ -82,7 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: dist
           pattern: envy-*-release

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,9 +13,6 @@ on:
 # Dependency review is handled by code-quality.yml.
 # This workflow adds secret scanning not covered elsewhere.
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   secret-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,8 +6,11 @@ on:
   pull_request:
     branches: [main, master, develop]
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: 0 0 * * 1
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 # CodeQL scanning is handled by codeql.yml.
 # Dependency review is handled by code-quality.yml.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,9 @@ on:
 # Dependency review is handled by code-quality.yml.
 # This workflow adds secret scanning not covered elsewhere.
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   secret-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,4 @@
+---
 name: Mark stale issues and PRs
 
 on:
@@ -23,14 +24,14 @@ jobs:
           days-before-issue-close: 14
           days-before-pr-stale: 45
           days-before-pr-close: 21
-          stale-issue-label: "stale"
-          stale-pr-label: "stale"
-          exempt-issue-labels: "pinned,security,roadmap"
-          exempt-pr-labels: "pinned,dependencies,security"
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,security,roadmap
+          exempt-pr-labels: pinned,dependencies,security
           stale-issue-message: >
-            This issue has been inactive for 90 days. It will be closed in 14 days
-            if no further activity occurs. Comment to keep it open.
+            This issue has been inactive for 90 days. It will be closed in
+            14 days if no further activity occurs. Comment to keep it open.
           stale-pr-message: >
-            This pull request has been inactive for 45 days. It will be closed in
-            21 days. Please rebase or comment to keep it open.
+            This pull request has been inactive for 45 days. It will be
+            closed in 21 days. Please rebase or comment to keep it open.
           operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   stale:

--- a/.github/workflows/version-management.yml
+++ b/.github/workflows/version-management.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   version-management:
     name: Version Management
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     steps:
       - name: Checkout code

--- a/.github/workflows/version-management.yml
+++ b/.github/workflows/version-management.yml
@@ -1,12 +1,13 @@
 name: Version Management
 
+# checkov:skip=CKV_GHA_7:Version bump inputs are required for manual release prep.
 on:
   workflow_dispatch:
     inputs:
       version_action:
-        description: 'Version action to perform'
+        description: Version action to perform
         required: true
-        default: 'patch'
+        default: patch
         type: choice
         options:
           - patch
@@ -14,15 +15,18 @@ on:
           - major
           - prerelease
       prerelease_label:
-        description: 'Pre-release label (only for prerelease action)'
+        description: Pre-release label (only for prerelease action)
         required: false
-        default: 'dev'
+        default: dev
         type: string
       update_files:
-        description: 'Update project files with new version'
+        description: Update project files with new version
         required: false
         default: true
         type: boolean
+
+permissions:
+  contents: write
 
 jobs:
   version-management:

--- a/.gitignore
+++ b/.gitignore
@@ -428,3 +428,4 @@ Plugins/SkinScan/SkinScan.h
 Plugins/VirusTotal/VirusTotal.h
 Plugins/WindowsThumbnail/WindowsThumbnail.h
 Plugins/ZIPBuilder/ZIPBuilder.h
+vcpkg/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **CI maintenance** — Pin Windows jobs to `windows-2025` / `windows-2025-vs2026`, upgrade `microsoft/setup-msbuild@v3` and artifact actions to v5, opt JavaScript actions into Node 24 where upstream lacks native builds, skip PR labeler and README advisory on zero-file pull requests.
+- **CI maintenance** — Pin Windows jobs to `windows-2025` / `windows-2025-vs2026`, upgrade `microsoft/setup-msbuild@v3` and artifact actions to v6, opt legacy JavaScript actions into Node 24 where needed, skip PR labeler and README advisory on zero-file or CI-only pull requests.
 
 ### Fixed
 - **Startup skin diagnostics** — Eliminated spurious `Skin load error: Toolbar Lookup` (for `CDownloadsWnd`, `CUploadsWnd`, `CNeighboursWnd`, `CIRCFrame`, `CLibraryTree.Top`, `CLibraryHeaderBar.Physical`, `CLibraryTileView.Physical`, `CLibraryTree.Physical`) and `Failed to load icon` (for command IDs 40156, 40158, 40320–40328, 40340, 40345) debug-log noise emitted at startup. Root cause: `CChildWnd::OnCreate` invokes the virtual `OnSkinChange()` (through `LoadState`) before `CMainWnd::OnSkinChanged` runs the first `Skin.Apply()`, so `CSkin::m_pToolbars` and the `CCoolInterface` image maps were still empty when child windows requested them. `CSkin` now lazily loads the embedded default skin on first toolbar / command-image lookup, and both `CSkin::CreateToolBar` and `CCoolInterface::ExtractIcon` deduplicate the remaining debug messages once per session. A debug-only `CSkin::ValidateLoaded()` runs at the end of `Skin.Apply()` to report toolbar / command-image counts and surface genuine missing built-in toolbar names or image IDs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **CI maintenance** — Pin Windows jobs to `windows-2025` / `windows-2025-vs2026`, upgrade `microsoft/setup-msbuild@v3` and artifact actions to v5, opt JavaScript actions into Node 24 where upstream lacks native builds, skip PR labeler and README advisory on zero-file pull requests.
+
 ### Fixed
 - **Startup skin diagnostics** — Eliminated spurious `Skin load error: Toolbar Lookup` (for `CDownloadsWnd`, `CUploadsWnd`, `CNeighboursWnd`, `CIRCFrame`, `CLibraryTree.Top`, `CLibraryHeaderBar.Physical`, `CLibraryTileView.Physical`, `CLibraryTree.Physical`) and `Failed to load icon` (for command IDs 40156, 40158, 40320–40328, 40340, 40345) debug-log noise emitted at startup. Root cause: `CChildWnd::OnCreate` invokes the virtual `OnSkinChange()` (through `LoadState`) before `CMainWnd::OnSkinChanged` runs the first `Skin.Apply()`, so `CSkin::m_pToolbars` and the `CCoolInterface` image maps were still empty when child windows requested them. `CSkin` now lazily loads the embedded default skin on first toolbar / command-image lookup, and both `CSkin::CreateToolBar` and `CCoolInterface::ExtractIcon` deduplicate the remaining debug messages once per session. A debug-only `CSkin::ValidateLoaded()` runs at the end of `Skin.Apply()` to report toolbar / command-image counts and surface genuine missing built-in toolbar names or image IDs.
 - **Missing built-in toolbar definition** — Added `<toolbar name="CLibraryTree.Physical"/>` to `Envy/Res/Default.xml` next to its `CLibraryTree.Virtual` counterpart. `CLibraryFrame::OnSkinChange` requests this name when `Settings.Library.ShowVirtual` is false, then hides `m_wndTreeBottom` (`SW_HIDE`) in Physical mode, so the empty definition resolves the lookup without changing any visible UI.

--- a/DEV_TRACKER.md
+++ b/DEV_TRACKER.md
@@ -21,10 +21,6 @@ For the canonical AI rules, see [`AGENTS.md`](./AGENTS.md).
 
 ## In progress
 
-- **2026-05-18** | ci/reduce-pr-check-warnings
-  -> CI-only: labeler/README guards for empty PRs, runner pins, Node 24
-  readiness (`setup-msbuild@v3`, artifact v5, `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`).
-
 - **2026-05-17** | claude/code-audit-modernization-nJcTT / PR #35
   -> Rebased onto `origin/develop` (base retargeted from `main`).
   Fixed second-wave C++20 errors: C7626 (`TOOLBAR_RES`,
@@ -42,6 +38,11 @@ _(none right now)_
 ---
 
 ## Done
+
+- **2026-05-18** | ci/reduce-pr-check-warnings | commit `2ce3bc0`
+  -> CI-only maintenance: zero-file PR guards for labeler/README advisory,
+  `windows-2025`/`windows-2025-vs2026` pins, `setup-msbuild@v3`,
+  artifact actions v5, `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` on legacy JS actions.
 
 - **2026-05-18** | fix/startup-skin-toolbar-icons | follow-up PR #43
   -> Closed the residual real miss: `CLibraryTree.Physical` was the

--- a/DEV_TRACKER.md
+++ b/DEV_TRACKER.md
@@ -21,6 +21,10 @@ For the canonical AI rules, see [`AGENTS.md`](./AGENTS.md).
 
 ## In progress
 
+- **2026-05-18** | ci/reduce-pr-check-warnings
+  -> CI-only: labeler/README guards for empty PRs, runner pins, Node 24
+  readiness (`setup-msbuild@v3`, artifact v5, `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`).
+
 - **2026-05-17** | claude/code-audit-modernization-nJcTT / PR #35
   -> Rebased onto `origin/develop` (base retargeted from `main`).
   Fixed second-wave C++20 errors: C7626 (`TOOLBAR_RES`,


### PR DESCRIPTION
## Summary
- Skip `actions/labeler@v6` when a PR has zero changed files (avoids the labeler skip warning).
- Pin ambiguous `windows-latest` to `windows-2025` or `windows-2025-vs2026` (v145 jobs stay on the VS 2026 image).
- Upgrade `microsoft/setup-msbuild@v3`, `actions/upload-artifact@v5`, `actions/download-artifact@v5`, and `actions/checkout@v5` (C# CodeQL workflow).
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on workflows that still use third-party JS actions without Node 24 releases.
- Bump Remote JS tests to Node 24; silence Documentation Check README notices on empty PRs only.

## Test plan
- [x] `git diff --check`
- [x] Python `yaml.safe_load` on all `.github/workflows/*.yml`
- [ ] Verify green checks on this PR (Build matrix on `windows-2025-vs2026`)
- [ ] Confirm labeler and Documentation Check produce no notices on a zero-file PR (close Dependabot PR #45 after merge)

## Notes
Close PR #45 without merge: it is a no-op vcpkg baseline bump with no file diff.
