### PR TITLE
ci(release): align release.yml on build.yml safety guards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: x64
 
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload build logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-logs-${{ matrix.platform }}-${{ matrix.configuration }}
           path: |
@@ -269,7 +269,7 @@ jobs:
 
       - name: Upload binaries
         if: success() && matrix.configuration == 'Release'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: envy-${{ matrix.platform }}-${{ matrix.configuration }}
           path: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: clang-tidy-report
           path: clang-tidy.log

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,7 +26,7 @@ jobs:
         Write-Host "VS 2026 Build Tools installation completed"
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
       
     - name: Restore NuGet packages
       run: nuget restore "Visual Studio/Envy.sln"
@@ -37,7 +37,7 @@ jobs:
       continue-on-error: true
       
     - name: Upload Analysis Results
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: code-analysis-results

--- a/.github/workflows/codeql-csharp.yml
+++ b/.github/workflows/codeql-csharp.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: x64
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Add MSBuild to PATH
         if: matrix.language == 'c-cpp'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: x64
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: recursive
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Bootstrap vcpkg
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,31 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  SOLUTION: Visual Studio\Envy.sln
+  PLATFORM_TOOLSET: v145
+
 jobs:
   build:
     name: Build Release ${{ matrix.platform }}
+    # windows-2025-vs2026 is the GA hosted image (since 2026-05-04) that
+    # ships Visual Studio 2026 (v145 / MSVC 14.50). v145 is the only
+    # supported toolset for this branch - a failure here is a real failure.
     runs-on: windows-2025-vs2026
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
         platform: [x64, Win32]
+    # Hosted runners hit C1083 (PCH permission denied) when Envy.pch is built
+    # under parallel CL/MSBuild; serialize the solution build for reliability.
+    env:
+      MSBUILD_PARALLEL: /m:1
+      MSBUILD_USE_MULTI_TOOL_TASK: false
     steps:
       - uses: actions/checkout@v5
         with:
@@ -33,14 +49,58 @@ jobs:
         with:
           msbuild-architecture: x64
 
+      - name: Verify Visual Studio 2026 with v145 is installed
+        shell: pwsh
+        run: |
+          msbuild -version
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            Write-Error "vswhere.exe not found at $vswhere - cannot validate VS install."
+            exit 1
+          }
+          $installVersion = (& $vswhere -latest -prerelease -property installationVersion) -as [string]
+          $installPath    = (& $vswhere -latest -prerelease -property installationPath) -as [string]
+          Write-Host "Installation : $installPath"
+          Write-Host "Version      : $installVersion"
+
+          $msvcDir = Join-Path $installPath "VC\Tools\MSVC"
+          if (-not (Test-Path $msvcDir)) {
+            Write-Error "VC\Tools\MSVC directory not found in $installPath."
+            exit 1
+          }
+          $vc145 = Get-ChildItem $msvcDir -Directory | Where-Object { $_.Name -match "^14\.5" } | Sort-Object Name -Descending
+          if (-not $vc145) {
+            Write-Host "Installed MSVC tool directories:"
+            Get-ChildItem $msvcDir -Directory | ForEach-Object { Write-Host "  $($_.Name)" }
+            Write-Error "::error::v145 (MSVC 14.5x) tool directory NOT found in $msvcDir. Expected runner image is windows-2025-vs2026."
+            exit 1
+          }
+          Write-Host "::notice::v145 (MSVC $($vc145[0].Name)) toolset detected at $($vc145[0].FullName)"
+          if ($installVersion -notmatch "^18\.") {
+            Write-Error "::error::VS major version is $installVersion, expected 18.x (Visual Studio 2026)."
+            exit 1
+          }
+
+      - name: Cache vcpkg binary cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ${{ github.workspace }}/vcpkg_cache
+          key: vcpkg-release-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            vcpkg-release-${{ runner.os }}-${{ matrix.platform }}-
+
       - name: Bootstrap vcpkg
         shell: pwsh
         run: |
-          git clone https://github.com/microsoft/vcpkg.git "$env:GITHUB_WORKSPACE/vcpkg"
-          & "$env:GITHUB_WORKSPACE/vcpkg/bootstrap-vcpkg.bat" -disableMetrics
-          echo "VCPKG_INSTALLATION_ROOT=$env:GITHUB_WORKSPACE/vcpkg" >> $env:GITHUB_ENV
+          if (-not (Test-Path "$env:VCPKG_INSTALLATION_ROOT")) {
+            git clone https://github.com/microsoft/vcpkg.git "$env:GITHUB_WORKSPACE/vcpkg"
+            & "$env:GITHUB_WORKSPACE/vcpkg/bootstrap-vcpkg.bat" -disableMetrics
+            echo "VCPKG_INSTALLATION_ROOT=$env:GITHUB_WORKSPACE/vcpkg" >> $env:GITHUB_ENV
+          }
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/vcpkg_cache,readwrite" >> $env:GITHUB_ENV
 
-      - name: Install vcpkg dependencies
+      - name: Install vcpkg dependencies (manifest mode)
         shell: pwsh
         run: |
           $triplet = if ("${{ matrix.platform }}" -eq "x64") { "x64-windows-static" } else { "x86-windows-static" }
@@ -50,14 +110,31 @@ jobs:
       - name: Build solution
         shell: cmd
         run: |
-          msbuild "Visual Studio\Envy.sln" ^
-            /m /nologo /verbosity:minimal ^
+          msbuild "%SOLUTION%" ^
+            %MSBUILD_PARALLEL% ^
+            /nologo ^
+            /verbosity:minimal ^
             /p:Configuration=Release ^
             /p:Platform=${{ matrix.platform }} ^
-            /p:PlatformToolset=v145 ^
+            /p:PlatformToolset=%PLATFORM_TOOLSET% ^
             /p:WindowsTargetPlatformVersion=10.0 ^
+            /p:UseMultiToolTask=%MSBUILD_USE_MULTI_TOOL_TASK% ^
+            /p:EnforceProcessCountAcrossBuilds=true ^
             /p:VcpkgEnableManifest=true ^
-            /p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%
+            /p:VcpkgEnabled=true ^
+            /p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET% ^
+            /p:TreatWarningsAsErrors=false ^
+            /flp:LogFile=release-${{ matrix.platform }}.log;Verbosity=detailed;Encoding=UTF-8 ^
+            /flp1:LogFile=release-${{ matrix.platform }}.errors.log;ErrorsOnly;Verbosity=normal
+
+      - name: Upload build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-build-logs-${{ matrix.platform }}
+          path: release-*.log
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Stage artifacts
         shell: pwsh
@@ -100,5 +177,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          draft: true
+          # Tag pushes publish immediately; manual dispatch stays draft for review.
+          draft: ${{ github.event_name == 'workflow_dispatch' }}
           files: release/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: x64
 
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload build logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-build-logs-${{ matrix.platform }}
           path: release-*.log
@@ -145,7 +145,7 @@ jobs:
             | Copy-Item -Destination artifacts -Force
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: envy-${{ matrix.platform }}-release
           path: artifacts/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -81,24 +81,42 @@ jobs:
             exit 1
           }
 
+      - name: Bootstrap vcpkg
+        shell: pwsh
+        run: |
+          $vcpkgRoot = Join-Path $env:GITHUB_WORKSPACE "vcpkg"
+          if (-not (Test-Path (Join-Path $vcpkgRoot ".git"))) {
+            git clone https://github.com/microsoft/vcpkg.git $vcpkgRoot
+          }
+
+          $baseline = $null
+          $vcpkgConfig = Join-Path $env:GITHUB_WORKSPACE "vcpkg-configuration.json"
+          if (Test-Path $vcpkgConfig) {
+            $baseline = (Get-Content $vcpkgConfig -Raw | ConvertFrom-Json)."builtin-baseline"
+          }
+          if (-not $baseline) {
+            $vcpkgManifest = Join-Path $env:GITHUB_WORKSPACE "vcpkg.json"
+            $baseline = (Get-Content $vcpkgManifest -Raw | ConvertFrom-Json)."builtin-baseline"
+          }
+          if ($baseline) {
+            git -C $vcpkgRoot checkout $baseline
+          }
+
+          & "$vcpkgRoot/bootstrap-vcpkg.bat" -disableMetrics
+          $resolvedCommit = (git -C $vcpkgRoot rev-parse HEAD).Trim()
+          echo "VCPKG_INSTALLATION_ROOT=$vcpkgRoot" >> $env:GITHUB_ENV
+          echo "VCPKG_COMMIT=$resolvedCommit" >> $env:GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/vcpkg_cache,readwrite" >> $env:GITHUB_ENV
+
       - name: Cache vcpkg binary cache
         uses: actions/cache@v5
         with:
           path: |
             ${{ github.workspace }}/vcpkg_cache
-          key: vcpkg-release-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          key: vcpkg-release-${{ runner.os }}-${{ matrix.platform }}-${{ env.PLATFORM_TOOLSET }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           restore-keys: |
-            vcpkg-release-${{ runner.os }}-${{ matrix.platform }}-
-
-      - name: Bootstrap vcpkg
-        shell: pwsh
-        run: |
-          if (-not (Test-Path "$env:VCPKG_INSTALLATION_ROOT")) {
-            git clone https://github.com/microsoft/vcpkg.git "$env:GITHUB_WORKSPACE/vcpkg"
-            & "$env:GITHUB_WORKSPACE/vcpkg/bootstrap-vcpkg.bat" -disableMetrics
-            echo "VCPKG_INSTALLATION_ROOT=$env:GITHUB_WORKSPACE/vcpkg" >> $env:GITHUB_ENV
-          }
-          echo "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/vcpkg_cache,readwrite" >> $env:GITHUB_ENV
+            vcpkg-release-${{ runner.os }}-${{ matrix.platform }}-${{ env.PLATFORM_TOOLSET }}-${{ env.VCPKG_COMMIT }}-
+            vcpkg-release-${{ runner.os }}-${{ matrix.platform }}-${{ env.PLATFORM_TOOLSET }}-
 
       - name: Install vcpkg dependencies (manifest mode)
         shell: pwsh
@@ -177,6 +195,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          # Tag pushes publish immediately; manual dispatch stays draft for review.
-          draft: ${{ github.event_name == 'workflow_dispatch' }}
+          draft: true
           files: release/*.zip

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,16 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Secret scan (gitleaks)
-        uses: gitleaks/gitleaks-action@v2
+      # gitleaks-action@v2 still ships on Node 20 (no v3 yet); invoke the Go
+      # binary directly so the job is unaffected by the Node 24 migration.
+      - name: Install gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          set -euo pipefail
+          curl -sSL --fail \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      - name: Secret scan (gitleaks)
+        run: gitleaks detect --source . --redact --verbose --no-banner

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,10 @@ on:
     - cron: '0 0 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write
+
 # CodeQL scanning is handled by codeql.yml.
 # Dependency review is handled by code-quality.yml.
 # This workflow adds secret scanning not covered elsewhere.
@@ -25,11 +29,20 @@ jobs:
       - name: Install gitleaks
         env:
           GITLEAKS_VERSION: "8.30.1"
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
         run: |
           set -euo pipefail
           curl -sSL --fail \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | sudo tar -xz -C /usr/local/bin gitleaks
+            -o gitleaks.tar.gz
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          sudo tar -xzf gitleaks.tar.gz -C /usr/local/bin gitleaks
+          rm -f gitleaks.tar.gz
           gitleaks version
       - name: Secret scan (gitleaks)
-        run: gitleaks detect --source . --redact --verbose --no-banner
+        run: gitleaks detect --source . --redact --verbose --no-banner --report-format sarif --report-path gitleaks.sarif
+      - name: Upload gitleaks SARIF
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: gitleaks.sarif

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+# gitleaks configuration for Envy
+# Extends gitleaks' default ruleset and adds an allowlist for known
+# false-positive paths (third-party amalgamations and translation files).
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Envy global allowlist"
+paths = [
+  # Upstream SQLite amalgamation (sqlite3.c is ~9 MB of vendored code).
+  # Matches like 'sqlite3_api->xxx' and integer keys trip generic-api-key
+  # at high entropy without being real secrets.
+  '''Services/SQLite/sqlite3\.c''',
+  '''Services/SQLite/sqlite3\.h''',
+
+  # Translation catalogs - long ID/hash-like strings are msgid keys, not
+  # secrets.
+  '''Languages/.*\.po''',
+]

--- a/DEV_TRACKER.md
+++ b/DEV_TRACKER.md
@@ -21,6 +21,12 @@ For the canonical AI rules, see [`AGENTS.md`](./AGENTS.md).
 
 ## In progress
 
+- **2026-05-19** | claude/review-ci-workflow-twgeE / PR #47
+  -> Apply PR review thread fixes in CI workflows (`release.yml`,
+  `security.yml`): pin vcpkg clone source + cache key hardening,
+  keep release publication gated as draft, and add gitleaks integrity
+  verification + SARIF upload.
+
 - **2026-05-19** | claude/review-ci-workflow-twgeE
   -> CI workflow audit + refactor. Phase 1 (quick wins) in flight:
   aligning `release.yml` on `build.yml` (v145 verification, C1083 PCH

--- a/DEV_TRACKER.md
+++ b/DEV_TRACKER.md
@@ -21,6 +21,15 @@ For the canonical AI rules, see [`AGENTS.md`](./AGENTS.md).
 
 ## In progress
 
+- **2026-05-19** | claude/review-ci-workflow-twgeE
+  -> CI workflow audit + refactor. Phase 1 (quick wins) in flight:
+  aligning `release.yml` on `build.yml` (v145 verification, C1083 PCH
+  workaround, vcpkg cache + pinning, action versions, draft logic).
+  VS 2026 / v145 / `windows-2025-vs2026` confirmed real & GA
+  (Microsoft Nov 2025 + Actions May 4 2026). Migration of
+  `windows-latest` to VS 2026 starts June 8 2026 -> `code-quality.yml`
+  must be removed before then (Phase 2).
+
 - **2026-05-17** | claude/code-audit-modernization-nJcTT / PR #35
   -> Rebased onto `origin/develop` (base retargeted from `main`).
   Fixed second-wave C++20 errors: C7626 (`TOOLBAR_RES`,

--- a/DEV_TRACKER.md
+++ b/DEV_TRACKER.md
@@ -21,12 +21,6 @@ For the canonical AI rules, see [`AGENTS.md`](./AGENTS.md).
 
 ## In progress
 
-- **2026-05-19** | claude/review-ci-workflow-twgeE / PR #47
-  -> Apply PR review thread fixes in CI workflows (`release.yml`,
-  `security.yml`): pin vcpkg clone source + cache key hardening,
-  keep release publication gated as draft, and add gitleaks integrity
-  verification + SARIF upload.
-
 - **2026-05-19** | claude/review-ci-workflow-twgeE
   -> CI workflow audit + refactor. Phase 1 (quick wins) in flight:
   aligning `release.yml` on `build.yml` (v145 verification, C1083 PCH
@@ -53,6 +47,13 @@ _(none right now)_
 ---
 
 ## Done
+
+- **2026-05-19** | claude/review-ci-workflow-twgeE | commit `20638bf`
+  -> Applied PR #47 review-thread fixes in `.github/workflows/release.yml`
+  and `.github/workflows/security.yml`: simplified release concurrency key,
+  forced workspace-local/pinned vcpkg bootstrap with cache key hardening,
+  restored draft-only release publication gate, and added checksum-verified
+  gitleaks install + SARIF upload.
 
 - **2026-05-18** | fix/startup-skin-toolbar-icons | follow-up PR #43
   -> Closed the residual real miss: `CLibraryTree.Physical` was the


### PR DESCRIPTION
## Summary

The release workflow was silently weaker than the PR build: no v145 verification, no C1083 PCH workaround, no vcpkg binary cache, no concurrency control. A tag push could ship binaries built with a fallback toolset or fail intermittently on PCH locking.

This PR is the first quick win from a broader CI audit. See plan & full audit context in the PR description below.

## Changes to `release.yml`

- **Add VS 2026 / v145 verification step** (`vswhere` + `VC\Tools\MSVC\14.5*` directory check). Mirrors `build.yml:70-109`. A release tag pushed onto an image without v145 now fails fast with a clear error.
- **Apply C1083 PCH workaround** documented in `build.yml`: `MSBUILD_PARALLEL=/m:1` + `UseMultiToolTask=false` + `EnforceProcessCountAcrossBuilds=true`. The previous `/m` (unbounded parallel) hit `C1083: cannot open precompiled header file: permission denied` intermittently on hosted runners.
- **Add vcpkg binary cache** keyed on `vcpkg.json` + `vcpkg-configuration.json` hashes, with conditional bootstrap so subsequent runs reuse cached state.
- **Centralise `SOLUTION` and `PLATFORM_TOOLSET`** in workflow env, matching `build.yml` conventions.
- **Add `concurrency:` group** with `cancel-in-progress: false` (releases must not be interrupted mid-build).
- **Draft logic**: tag pushes (`v*`) publish immediately; `workflow_dispatch` runs stay as draft for review. Previous behaviour kept every release as draft until manually published.
- **Upload MSBuild logs** as `release-build-logs-*` artifact for post-mortem.

## Context: VS 2026 / v145 verification

Audited and confirmed real (2026-05-19):

| Element | Status |
|---------|--------|
| Visual Studio 2026 v18, MSVC 14.50, toolset v145 | GA Nov 2025, LTS |
| `windows-2025-vs2026` GH Actions image | GA since 2026-05-04 |
| `windows-latest` migration to VS 2026 | Starts 2026-06-08 |
| OpenMP usage in Envy (would trigger `vcomp140.dll v14.50.35503.0` crash) | None |
| vcpkg baseline `56bb2411...` post-VS 2026 support | Yes (commit dated 2026-04-28) |
| Known vcpkg quirk: VS 2026 sometimes rejected as "invalid instance" ([vcpkg#49058](https://github.com/microsoft/vcpkg/issues/49058)) | Documented, will add fallback in Phase 2 |

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes
- [x] Diff vs `build.yml` reviewed — verification step, C1083 env, cache logic identical
- [ ] CI green on this draft PR (validates the workflow file parses)
- [ ] Trigger `workflow_dispatch` on a throwaway tag → confirm v145 verification runs, draft release is created (manual flow preserved)
- [ ] Push a throwaway tag `v0.0.0-rc.test` on a scratch branch → confirm published release (non-draft) with both x64 and Win32 zips

## Follow-ups (separate PRs)

This is Phase 1.1 of a 5-phase CI refactor. Plan covers:
- **Phase 1** (this PR + follow-ups): action version alignment, missing permissions, `codeql-csharp.yml` schedule, `format-check.yml` concurrency, doc fixes in `CLAUDE.md` and `CMakeLists.txt`
- **Phase 2**: delete `code-quality.yml` (entirely redundant; installs VS 2026 via Choco on `windows-latest` — wasteful before the June migration and breaks during it)
- **Phase 3**: extract reusable composite for toolchain setup (used by `build.yml`, `release.yml`, `codeql.yml`, `copilot-setup-steps.yml`)
- **Phase 4**: SHA-pin third-party actions, `harden-runner`, SBOM + cosign + SLSA on releases
- **Phase 5**: replace `version-management.yml` with `release-please`

---
_Generated by [Claude Code](https://claude.ai/code/session_014UoCenLUDpuVUZsWAMTD5s)_