### PR TITLE
docs: document linear history workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,8 +59,9 @@ commits:
 git config pull.ff only
 ```
 
-To apply repo-wide for all clones of this repository, each contributor can
-run the command above in their local clone.
+This configures fast-forward-only pulls for this local clone. To apply
+it globally across all your repositories instead, run
+`git config --global pull.ff only`.
 
 ### Sync `develop` locally
 
@@ -71,7 +72,8 @@ git pull --ff-only origin develop
 ```
 
 If `git pull --ff-only` fails, your local `develop` has diverged. Reset it
-to the remote (safe when you have no local-only commits on `develop`):
+to the remote (**ensure your working tree is clean first — `git reset --hard`
+discards all uncommitted changes**; stash or commit any work in progress):
 
 ```bash
 git fetch origin

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,10 +32,73 @@ to retarget every project to v145.
 ## Branch model
 
 - `main` - stable, releases tagged `v*` from here.
-- `develop` - integration branch.
+- `develop` - integration branch (default).
 - `legacy` - frozen pre-modernization snapshot for historical builds.
 - Feature branches : `feature/<short-name>` or `claude/<short-name>` for
   AI-assisted work.
+
+## Git workflow (linear history)
+
+`develop` keeps a **linear first-parent history** going forward. Two older
+merge commits remain in history; do not rewrite them.
+
+### Repository merge settings (GitHub)
+
+- Merge commits: **disabled**
+- Squash merge: **enabled** (preferred)
+- Rebase merge: **enabled** (optional)
+- Require linear history on `develop`: enable in branch protection (see below)
+
+### Local settings
+
+Configure fast-forward-only pulls so a plain `git pull` never creates merge
+commits:
+
+```bash
+git config pull.ff only
+```
+
+To apply repo-wide for all clones of this repository, each contributor can
+run the command above in their local clone.
+
+### Sync `develop` locally
+
+```bash
+git fetch origin
+git checkout develop
+git pull --ff-only origin develop
+```
+
+If `git pull --ff-only` fails, your local `develop` has diverged. Reset it
+to the remote (safe when you have no local-only commits on `develop`):
+
+```bash
+git fetch origin
+git checkout develop
+git reset --hard origin/develop
+```
+
+Never commit directly on `develop`; always use a feature branch and PR.
+
+### Feature branch workflow (before opening or updating a PR)
+
+```bash
+git fetch origin
+git checkout your-feature-branch
+git rebase origin/develop
+git push --force-with-lease
+```
+
+Use `--force-with-lease`, not `--force`, so you do not overwrite someone
+else's pushed work.
+
+### Enable linear history on GitHub (one-time, admin)
+
+In **Settings → Branches → Branch protection rules → `develop`**, enable
+**Require linear history**. If branch protection is not configured yet, add
+a rule for `develop` with at least that checkbox. The declarative template
+in `.github/settings.yml` documents the intended protection shape for
+Probot Settings or manual alignment.
 
 ## Pull request checklist
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,15 +39,16 @@ to retarget every project to v145.
 
 ## Git workflow (linear history)
 
-`develop` keeps a **linear first-parent history** going forward. Two older
-merge commits remain in history; do not rewrite them.
+`develop` keeps a **linear history** with no merge commits. Keep local pulls
+fast-forward-only and rebase feature branches before opening or updating PRs.
 
 ### Repository merge settings (GitHub)
 
 - Merge commits: **disabled**
 - Squash merge: **enabled** (preferred)
 - Rebase merge: **enabled** (optional)
-- Require linear history on `develop`: enable in branch protection (see below)
+- Require linear history on `develop`: **enabled** via the active `Protect develop` ruleset
+- Force pushes and branch deletions on `develop`: **blocked**
 
 ### Local settings
 
@@ -92,13 +93,12 @@ git push --force-with-lease
 Use `--force-with-lease`, not `--force`, so you do not overwrite someone
 else's pushed work.
 
-### Enable linear history on GitHub (one-time, admin)
+### Protected branch policy
 
-In **Settings → Branches → Branch protection rules → `develop`**, enable
-**Require linear history**. If branch protection is not configured yet, add
-a rule for `develop` with at least that checkbox. The declarative template
-in `.github/settings.yml` documents the intended protection shape for
-Probot Settings or manual alignment.
+The active `Protect develop` ruleset requires pull requests, linear history,
+passing status checks, and blocks force-pushes and branch deletion. The
+declarative template in `.github/settings.yml` mirrors this intended policy
+for Probot Settings or manual audits.
 
 ## Pull request checklist
 

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -26,7 +26,7 @@ repository:
   has_downloads: true
   default_branch: develop
   allow_squash_merge: true
-  allow_merge_commit: true
+  allow_merge_commit: false
   allow_rebase_merge: true
   delete_branch_on_merge: true
   enable_automated_security_fixes: true
@@ -195,6 +195,7 @@ milestones:
 branches:
   - name: develop
     protection:
+      required_linear_history: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         dismiss_stale_reviews: true
@@ -206,4 +207,6 @@ branches:
           - "Build and Test (x64)"
           - "CodeQL Security Scan"
       enforce_admins: false
+      allow_force_pushes: false
+      allow_deletions: false
       restrictions: null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Git workflow / linear history** — Documented squash-or-rebase merge policy for `develop`, `git pull --ff-only` local hygiene, and feature-branch rebase commands in `.github/CONTRIBUTING.md`, `docs/CONTRIBUTING.md`, and `docs/PR_PLAYBOOK.md`. Aligned `.github/settings.yml` with GitHub (merge commits off; squash and rebase on). Enabled rebase merge on GitHub to match.
+- **Git workflow / linear history** — Documented squash-or-rebase merge policy for `develop`, `git pull --ff-only` local hygiene, and feature-branch rebase commands in `.github/CONTRIBUTING.md`, `docs/CONTRIBUTING.md`, and `docs/PR_PLAYBOOK.md`. Aligned `.github/settings.yml` with GitHub by disabling merge commits while keeping squash and rebase merges enabled, and tightening branch protection settings to match.
 - **CI maintenance** — Pin Windows jobs to `windows-2025` / `windows-2025-vs2026`, upgrade `microsoft/setup-msbuild@v3` and artifact actions to v6, opt legacy JavaScript actions into Node 24 where needed, skip PR labeler and README advisory on zero-file or CI-only pull requests.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Git workflow / linear history** — Documented squash-or-rebase merge policy for `develop`, `git pull --ff-only` local hygiene, and feature-branch rebase commands in `.github/CONTRIBUTING.md`, `docs/CONTRIBUTING.md`, and `docs/PR_PLAYBOOK.md`. Aligned `.github/settings.yml` with GitHub (merge commits off; squash and rebase on). Enabled rebase merge on GitHub to match.
 - **CI maintenance** — Pin Windows jobs to `windows-2025` / `windows-2025-vs2026`, upgrade `microsoft/setup-msbuild@v3` and artifact actions to v6, opt legacy JavaScript actions into Node 24 where needed, skip PR labeler and README advisory on zero-file or CI-only pull requests.
 
 ### Fixed

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,15 +1,28 @@
 # Contributing
 
 ## Workflow
-1. Create a feature branch from `main` (or active integration branch).
+1. Create a feature branch from `develop` (default integration branch).
 2. Keep changes scoped (docs, code, CI, etc.) and submit focused PRs.
 3. Run relevant local checks before opening PR.
 4. Use PR template and include risk/testing notes.
 
 ## Branch and Commit Strategy
-- Prefer small, logical commits.
+- Prefer small, logical commits on feature branches.
+- Rebase feature branches onto `origin/develop` before opening or updating a PR.
+- Merge via **squash** (preferred) or **rebase** on GitHub; merge commits are disabled.
+- Use `git pull --ff-only` on `develop`; never merge `develop` locally.
 - Use imperative, specific commit messages.
 - Separate refactors from behavior changes where possible.
+
+### Sync commands (feature branches)
+
+```bash
+git fetch origin
+git rebase origin/develop
+git push --force-with-lease
+```
+
+See `.github/CONTRIBUTING.md` for the full linear-history workflow.
 
 ## Code Style
 - Follow existing C++ conventions in touched files.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,15 +14,7 @@
 - Use imperative, specific commit messages.
 - Separate refactors from behavior changes where possible.
 
-### Sync commands (feature branches)
-
-```bash
-git fetch origin
-git rebase origin/develop
-git push --force-with-lease
-```
-
-See `.github/CONTRIBUTING.md` for the full linear-history workflow.
+See `.github/CONTRIBUTING.md` for the canonical linear-history workflow and exact sync commands.
 
 ## Code Style
 - Follow existing C++ conventions in touched files.

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -22,7 +22,7 @@
 - Default branch is `develop`.
 - `main` is currently behind `develop`.
 - **Merge policy (GitHub):** merge commits disabled; squash and rebase merges enabled. Prefer squash for PRs.
-- **History:** `develop` was rewritten to a linear history with no merge commits; the old tree is preserved in the backup branch/tag created before the rewrite.
+- **History:** `develop` was rewritten to a linear history with no merge commits; the old tree is preserved in the `backup/develop-before-linear-rewrite` branch (and tag of the same name) created before the rewrite.
 - **Local hygiene:** use `git pull --ff-only` on `develop`; rebase feature branches with `git rebase origin/develop` and `git push --force-with-lease`.
 - **Branch protection:** the active `Protect develop` ruleset requires pull requests, linear history, passing checks, and blocks force-pushes/deletions. `.github/settings.yml` mirrors the intended policy for Probot Settings or manual audits.
 - CI workflows exist, but should not yet be treated as mandatory merge gates until required checks are consistently emitted and stable in GitHub Actions.

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -22,9 +22,9 @@
 - Default branch is `develop`.
 - `main` is currently behind `develop`.
 - **Merge policy (GitHub):** merge commits disabled; squash and rebase merges enabled. Prefer squash for PRs.
-- **History:** two legacy merge commits remain in pushed history (`e92d930`, `320dbe3`); recent integration is linear (squash merges). Do not rewrite `origin/develop` to remove them.
+- **History:** `develop` was rewritten to a linear history with no merge commits; the old tree is preserved in the backup branch/tag created before the rewrite.
 - **Local hygiene:** use `git pull --ff-only` on `develop`; rebase feature branches with `git rebase origin/develop` and `git push --force-with-lease`.
-- **Branch protection:** not yet enforced on GitHub; enable **Require linear history** on `develop` when ready (template in `.github/settings.yml`).
+- **Branch protection:** the active `Protect develop` ruleset requires pull requests, linear history, passing checks, and blocks force-pushes/deletions. `.github/settings.yml` mirrors the intended policy for Probot Settings or manual audits.
 - CI workflows exist, but should not yet be treated as mandatory merge gates until required checks are consistently emitted and stable in GitHub Actions.
 - Dependabot expects GitHub labels `ci` and `dependencies` to exist for automated PR labeling.
 
@@ -82,7 +82,7 @@
 - Archive legacy `.vcproj` files once migration is complete
 
 ## Decisions Log
-- **2026-05-27:** Keep existing pushed merge commits on `develop`; enforce linear history going forward via GitHub merge settings (no merge commits; squash/rebase only), contributor `git pull --ff-only`, and eventual branch-protection **Require linear history**.
+- **2026-05-27:** Rewrote `develop` into a linear history with no merge commits while preserving the final tree through backup refs; enforce linear history going forward via the active `Protect develop` ruleset, GitHub merge settings (no merge commits; squash/rebase only), and contributor `git pull --ff-only` hygiene.
 - **2026-05-15:** Repository hygiene baseline on `develop` requires explicit branch-state tracking and GitHub label prerequisites (`ci`, `dependencies`) before enforcing CI as mandatory gates.
 - **2026-04-22:** Added IPv6 dual-stack Phase 0 scoping inventory and phased rollout plan under `docs/ipv6/`.
 - **2026-04-22:** Remote web UI must use cryptographic token generation (`crypto.getRandomValues`) and allowlist-based redirect validation for all client-side navigation paths.

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -2,7 +2,8 @@
 
 > **LIVING DOCUMENT** — Must be updated after every meaningful change (feature, architectural decision, scope change, blocker resolution).
 
-- **Last Updated:** 2026-05-17
+- **Last Updated:** 2026-05-27
+- **Changelog Entry:** 2026-05-27 — Documented linear-history workflow for `develop`: squash/rebase merges only, `git pull --ff-only`, feature-branch rebase commands; aligned `.github/settings.yml` with GitHub merge settings.
 - **Changelog Entry:** 2026-05-17 — Improved CodeQL C# analysis precision by introducing a dedicated manual-build workflow and documenting legacy FictionBookReader build blockers plus minimal .NET Framework 4.8 retarget path.
 - **Changelog Entry:** 2026-05-15 — Synced repository hygiene status for `develop`: documented branch state, CI gate maturity, Dependabot labels requirement, and dependency register status (`docs/DEPENDENCIES.md` exists but remains an incomplete seed).
 - **Changelog Entry:** 2026-05-15 — Hardened legacy Kad publish packet construction by replacing unsafe keyword copy with bounded copy and explicit terminator in `KadProtocol::CreatePublishRequest`, preserving wire format.
@@ -20,6 +21,10 @@
 ## Repository Status (develop)
 - Default branch is `develop`.
 - `main` is currently behind `develop`.
+- **Merge policy (GitHub):** merge commits disabled; squash and rebase merges enabled. Prefer squash for PRs.
+- **History:** two legacy merge commits remain in pushed history (`e92d930`, `320dbe3`); recent integration is linear (squash merges). Do not rewrite `origin/develop` to remove them.
+- **Local hygiene:** use `git pull --ff-only` on `develop`; rebase feature branches with `git rebase origin/develop` and `git push --force-with-lease`.
+- **Branch protection:** not yet enforced on GitHub; enable **Require linear history** on `develop` when ready (template in `.github/settings.yml`).
 - CI workflows exist, but should not yet be treated as mandatory merge gates until required checks are consistently emitted and stable in GitHub Actions.
 - Dependabot expects GitHub labels `ci` and `dependencies` to exist for automated PR labeling.
 
@@ -77,6 +82,7 @@
 - Archive legacy `.vcproj` files once migration is complete
 
 ## Decisions Log
+- **2026-05-27:** Keep existing pushed merge commits on `develop`; enforce linear history going forward via GitHub merge settings (no merge commits; squash/rebase only), contributor `git pull --ff-only`, and eventual branch-protection **Require linear history**.
 - **2026-05-15:** Repository hygiene baseline on `develop` requires explicit branch-state tracking and GitHub label prerequisites (`ci`, `dependencies`) before enforcing CI as mandatory gates.
 - **2026-04-22:** Added IPv6 dual-stack Phase 0 scoping inventory and phased rollout plan under `docs/ipv6/`.
 - **2026-04-22:** Remote web UI must use cryptographic token generation (`crypto.getRandomValues`) and allowlist-based redirect validation for all client-side navigation paths.

--- a/docs/PR_PLAYBOOK.md
+++ b/docs/PR_PLAYBOOK.md
@@ -5,6 +5,8 @@ Use this playbook to keep PRs small, reviewable, and operationally safe.
 ## Global Expectations (All PR Types)
 
 - One logical change area per PR.
+- Branch from `develop`; rebase onto `origin/develop` before merge.
+- Merge with **squash** (preferred) or **rebase**; merge commits are disabled on GitHub.
 - Report:
   - testing performed
   - testing not performed
@@ -13,6 +15,27 @@ Use this playbook to keep PRs small, reviewable, and operationally safe.
 - Update under `[Unreleased]` in `CHANGELOG.md`.
 - Update `docs/DEVELOPMENT_PLAN.md` for strategic/scope decisions.
 - Update `docs/DEV_TRACKER.md` for operational status changes.
+
+## Git sync (feature branches)
+
+Before opening a PR or after `develop` moves forward:
+
+```bash
+git fetch origin
+git checkout your-feature-branch
+git rebase origin/develop
+git push --force-with-lease
+```
+
+Keep local `develop` aligned without merge commits:
+
+```bash
+git fetch origin
+git checkout develop
+git pull --ff-only origin develop
+```
+
+Configure once per clone: `git config pull.ff only`
 
 ## Documentation PR Checklist
 

--- a/docs/PR_PLAYBOOK.md
+++ b/docs/PR_PLAYBOOK.md
@@ -16,26 +16,9 @@ Use this playbook to keep PRs small, reviewable, and operationally safe.
 - Update `docs/DEVELOPMENT_PLAN.md` for strategic/scope decisions.
 - Update `docs/DEV_TRACKER.md` for operational status changes.
 
-## Git sync (feature branches)
+## Git sync
 
-Before opening a PR or after `develop` moves forward:
-
-```bash
-git fetch origin
-git checkout your-feature-branch
-git rebase origin/develop
-git push --force-with-lease
-```
-
-Keep local `develop` aligned without merge commits:
-
-```bash
-git fetch origin
-git checkout develop
-git pull --ff-only origin develop
-```
-
-Configure once per clone: `git config pull.ff only`
+Use `.github/CONTRIBUTING.md` as the canonical source for the linear-history workflow and exact `git fetch` / `git rebase origin/develop` / `git push --force-with-lease` commands.
 
 ## Documentation PR Checklist
 

--- a/docs/PR_PLAYBOOK.md
+++ b/docs/PR_PLAYBOOK.md
@@ -5,8 +5,6 @@ Use this playbook to keep PRs small, reviewable, and operationally safe.
 ## Global Expectations (All PR Types)
 
 - One logical change area per PR.
-- Branch from `develop`; rebase onto `origin/develop` before merge.
-- Merge with **squash** (preferred) or **rebase**; merge commits are disabled on GitHub.
 - Report:
   - testing performed
   - testing not performed


### PR DESCRIPTION
Documents the repository linear-history policy, safe rebase workflow, and protected-branch merge rules. No source code changes.

## Summary
- **What changed?** Contributor-facing documentation updated to describe the linear-history workflow enforced on `develop`: squash/rebase merge policy, `git pull --ff-only` hygiene, feature-branch rebase commands, and protected-branch settings. Addressed follow-up review feedback to improve accuracy and clarity.
- **Why now?** `develop` was rewritten to a linear history; contributors need clear, consistent guidance on how to work with it going forward.

## Scope
- [ ] Code
- [x] Docs
- [ ] CI/Tooling
- [ ] Security
- [ ] Dependencies

## Validation
- Markdown renders cleanly in GitHub preview.
- All changed files are documentation only; no build or runtime behavior affected.

## Risk Assessment
- Breaking changes: None — documentation only.
- Security impact: None.
- Performance impact: None.
- Rollback plan: Revert the doc commits; no state to unwind.

## Checklist
- [x] Changes are scoped and reviewable
- [ ] Tests added/updated where practical
- [x] Documentation updated
- [x] Changelog updated

### Changes made in response to review feedback
- **`docs/DEVELOPMENT_PLAN.md`** — Named the actual backup ref (`backup/develop-before-linear-rewrite` branch and tag) instead of the vague "backup branch/tag".
- **`docs/PR_PLAYBOOK.md`** — Removed duplicate inline merge-workflow rules (branch-from-develop / squash-or-rebase) that were already covered by the canonical `.github/CONTRIBUTING.md` pointer in the same file.
- **`.github/CONTRIBUTING.md`** — Clarified that `git config pull.ff only` applies to the local clone only, and offered `git config --global pull.ff only` for users who want the setting applied across all repositories.
- **`.github/CONTRIBUTING.md`** — Added an explicit warning that `git reset --hard` discards all uncommitted changes (not just local commits); users should stash or commit work in progress before running the command.