### PR TITLE
docs(rules): add branch-naming and merge-gate approval rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,14 @@ Envy is a multi-network peer-to-peer client for Windows. Stack:
 - **License**: AGPL-3.0-or-later (`Envy/AGPL-License.txt`). Some bundled
   resources have additional CC-BY-NC-SA terms - see `ReadMe.txt`.
 
-Branch model: develop on `claude/code-audit-modernization-nJcTT`
-(per session instructions). Do **not** push to `main`, `develop`, or
-`legacy` directly.
+Branch model: the default branch is `develop` (linear history). Branch off
+`develop` using conventional `type/short-kebab-summary` names - `feat/`,
+`fix/`, `docs/`, `refactor/`, `perf/`, `test/`, `build/`, `ci/`, `chore/`
+(plus `hotfix/`), matching the Conventional Commit types this repo already
+uses. Never create or push agent-/tool-prefixed branches (e.g. `claude/...`).
+You may push your own feature branch and open a **draft** PR freely; never
+push to `main`, `develop`, or `legacy` directly, and never merge without
+maintainer approval.
 
 ---
 
@@ -66,6 +71,17 @@ Branch model: develop on `claude/code-audit-modernization-nJcTT`
 10. **Never skip git hooks** (`--no-verify`, `--no-gpg-sign`) and never
     force-push to `main` or `develop`. Always create new commits rather
     than amending.
+11. **Branch naming**. Never create or push `claude/`-prefixed (or any
+    agent-/tool-prefixed) branches. Use conventional
+    `type/short-kebab-summary` names - `feat/`, `fix/`, `docs/`,
+    `refactor/`, `perf/`, `test/`, `build/`, `ci/`, `chore/` (plus
+    `hotfix/`), matching the Conventional Commit types - branched off
+    `develop`.
+12. **Human approval at the merge gate**. An assistant may commit and push
+    to its *own* feature branch and open **draft** PRs (so CI runs and the
+    diff is reviewable), but must **not** merge, mark a PR ready-for-review,
+    or push to `main`/`develop`/`legacy` without explicit maintainer
+    approval. The agent proposes; the maintainer owns the merge.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Agent branch & merge-gate rules** — Added branch-naming and merge-gate approval rules to `AGENTS.md` (hard rules 11-12 + branch-model paragraph) and `CLAUDE.md`: assistants use conventional `type/short-kebab-summary` branches matching Conventional Commit types (no `claude/`-prefixed or tool-prefixed branches), may push their own feature branch and open draft PRs, but must not merge or push to `main`/`develop` without explicit maintainer approval. Documentation only.
 - **Git workflow / linear history** — Documented squash-or-rebase merge policy for `develop`, `git pull --ff-only` local hygiene, and feature-branch rebase commands in `.github/CONTRIBUTING.md`, `docs/CONTRIBUTING.md`, and `docs/PR_PLAYBOOK.md`. Aligned `.github/settings.yml` with GitHub by disabling merge commits while keeping squash and rebase merges enabled, and tightening branch protection settings to match.
 - **CI maintenance** — Pin Windows jobs to `windows-2025` / `windows-2025-vs2026`, upgrade `microsoft/setup-msbuild@v3` and artifact actions to v6, opt legacy JavaScript actions into Node 24 where needed, skip PR labeler and README advisory on zero-file or CI-only pull requests.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,11 @@ msbuild "Visual Studio\Envy.sln" /m /p:Configuration=Release /p:Platform=x64 ^
 1. **Read** [`DEV_TRACKER.md`](./DEV_TRACKER.md) to see what's in flight.
 2. **Update** the tracker at start (Backlog -> In progress) and end
    (In progress -> Done with date, commit, outcome).
-3. **Push** only to the branch the session was assigned to.
+3. **Branch & merge gate.** Use conventional branch names off `develop`
+   (`feat/`, `fix/`, `docs/`, `ci/`, ...); never use `claude/`-prefixed
+   branches. You may push your own branch and open **draft** PRs, but never
+   merge or push to `develop`/`main` without explicit approval.
+   (See AGENTS.md section 2, rules 11-12.)
 4. **Reply to the user in the language they used in chat**, but all
    commits, comments, docs, and PR text in **English**.
 


### PR DESCRIPTION
## Summary

Encodes the agreed AI-assistant workflow norms in the governance rule files,
following a check against current best practices (Conventional Commits branch
types; "agent proposes, maintainer owns the merge" — GitHub's documented
agentic-workflow guidance).

This also fixes part of **P0 item 1** from the audit (`docs/audit/2026-06-06-…`):
the `AGENTS.md` branch-model paragraph still named the old `claude/…` session
branch.

### What changes (documentation only)
- **`AGENTS.md`** — rewrites the branch-model paragraph and adds hard rules
  **11 & 12**:
  - **11. Branch naming** — conventional `type/short-kebab-summary` names
    matching the Conventional Commit types (`feat/ fix/ docs/ refactor/ perf/
    test/ build/ ci/ chore/`, plus `hotfix/`), branched off `develop`. No
    `claude/`-prefixed or other agent-/tool-prefixed branches.
  - **12. Human approval at the merge gate** — an assistant may commit/push to
    its *own* feature branch and open **draft** PRs (CI runs, diff reviewable),
    but must not merge, mark ready-for-review, or push to
    `main`/`develop`/`legacy` without explicit maintainer approval.
- **`CLAUDE.md`** — rewrites mandatory step 3 to match.
- **`CHANGELOG.md`** — `[Unreleased]` entry.

## Scope
- [ ] Code
- [x] Docs
- [ ] CI/Tooling
- [ ] Security
- [ ] Dependencies

## Validation
- `git diff --check` — clean. Documentation only; no source/workflow files.

## Risk Assessment
- None (governance docs only). This PR is **draft** and will not be merged
  without maintainer approval, per the very rule it adds.

## Checklist
- [x] Changes are scoped and reviewable
- [x] Documentation updated
- [x] Changelog updated (`[Unreleased]`)

https://claude.ai/code/session_01CA6HJzyQqKALYmzLMbYj84

---
_Generated by [Claude Code](https://claude.ai/code/session_01CA6HJzyQqKALYmzLMbYj84)_