### PR TITLE
docs: align branch and merge governance rules

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -5,8 +5,8 @@
 Before making changes, read AGENTS.md and docs/DEV_TRACKER.md.
 
 Required:
-- Push only to the branch the session is pinned to (never main, develop,
-  or legacy).
+- Branch off develop; push only your feature branch (never main, develop,
+  or legacy). Use type/short-kebab-summary names; no tool/agent prefixes.
 - Update docs/DEV_TRACKER.md when starting and finishing a task.
 - All artifacts (code, comments, commits, PRs, docs) in English; chat
   replies follow the user's language.

--- a/.continue/rules/envy.md
+++ b/.continue/rules/envy.md
@@ -17,7 +17,8 @@ Full ruleset: `AGENTS.md`. This file is a pointer.
 - **Language**: English for code, comments, commits, PRs, docs; chat
   follows the user.
 - **Tracking**: update `docs/DEV_TRACKER.md` at the start and end of each task.
-- **Branch discipline**: push only to the assigned branch.
+- **Branch discipline**: branch off develop; push only your feature branch.
+  Use type/short-kebab-summary names; no tool/agent prefixes.
 
 Build command:
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -19,8 +19,9 @@ Read AGENTS.md before acting on this repo. Highlights:
 6. Never edit files under Plugins/PluginWizard/** (project templates).
 7. Never bulk-format existing files. .clang-format is advisory.
 8. Always update docs/DEV_TRACKER.md when you start and finish a task.
-9. Push only to the branch the session is pinned to. Never push to
-   main, develop, or legacy.
+9. Branch off develop with conventional type/short-kebab-summary names;
+   push only your feature branch. Never push to main, develop, or legacy.
+   Never use claude/, cursor/, or other tool/agent branch prefixes.
 10. `throw()` is removed in C++20 - use `noexcept`. `register` is
     removed in C++17 - drop it. Source files in this repo are mixed
     encoding (ISO-8859/UTF-8) - never bulk-convert.
@@ -33,9 +34,9 @@ Style:
 - Headers include StdAfx.h first.
 
 Branch model:
-- main: protected, only merges from PRs.
-- develop: integration.
+- develop: default integration branch (linear history).
+- main: protected stable branch.
 - legacy: frozen pre-modernization snapshot.
-- claude/* or feature/*: working branches.
+- Work branches: type/short-kebab-summary off develop (feat/, fix/, docs/, …).
 
 See MODERNIZATION.md for the full multi-phase plan.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -11,7 +11,7 @@ Hard rules:
    C++20 first-party, C++17 legacy plugins).
 3. Windows 10 1809+ target. Never re-introduce XP support.
 4. Dependencies via vcpkg manifest (vcpkg.json).
-5. Push only to the branch the session is pinned to. Update
+5. Branch off develop; push only your feature branch. Update
    docs/DEV_TRACKER.md at the start and end of each task.
 6. Don't bulk-reformat. Don't edit Plugins/PluginWizard/**.
 7. Match the legacy MFC style: tabs/4, Allman braces, Hungarian

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,15 @@ Envy is a multi-network peer-to-peer client for Windows. Stack:
 - **License**: AGPL-3.0-or-later (`Envy/AGPL-License.txt`). Some bundled
   resources have additional CC-BY-NC-SA terms - see `ReadMe.txt`.
 
-Branch model: develop on `claude/code-audit-modernization-nJcTT`
-(per session instructions). Do **not** push to `main`, `develop`, or
-`legacy` directly.
+Branch model:
+
+- **`develop`** is the active integration branch and the repository default.
+- Create every work branch from the latest **`origin/develop`**.
+- Never push directly to **`develop`**, **`main`**, or **`legacy`**; land
+  changes through a pull request to **`develop`**.
+- Keep **`develop`** history **linear**: merge PRs with **squash** or
+  **rebase** only; ordinary merge commits are not allowed on **`develop`**.
+- Branch names use `type/short-kebab-summary` (see hard rule 11).
 
 ---
 
@@ -66,6 +72,22 @@ Branch model: develop on `claude/code-audit-modernization-nJcTT`
 10. **Never skip git hooks** (`--no-verify`, `--no-gpg-sign`) and never
     force-push to `main` or `develop`. Always create new commits rather
     than amending.
+11. **Branch naming**. Use functional `type/short-kebab-summary` names
+    branched off `develop`. Allowed prefixes include `feat/`, `fix/`,
+    `docs/`, `refactor/`, `perf/`, `test/`, `build/`, `ci/`, `chore/`,
+    and `hotfix/`. Examples: `fix/ed2k-source-validation`,
+    `docs/align-development-rules`, `ci/add-pr-quick-checks`,
+    `security/configure-scorecard`. Never create or push tool- or
+    agent-prefixed branches such as `claude/`, `cursor/`, `codex/`,
+    `aider/`, `copilot/`, or `agent/`; the name must describe the change,
+    not the tool that produced it.
+12. **Human approval at the merge gate**. An assistant may create a work
+    branch, commit on that branch, push the branch, and open a **draft**
+    PR. An assistant must **not** mark a PR ready-for-review, enable
+    auto-merge, or merge without explicit maintainer approval. When a
+    maintainer explicitly instructs you to merge a specific PR after its
+    checks pass, you may perform that merge. Never push to
+    `main`/`develop`/`legacy` directly.
 
 ---
 
@@ -90,6 +112,14 @@ msbuild HashLib\HashTest\HashTest.vcxproj /p:Configuration=Release /p:Platform=x
 
 There is no `make test` or `cargo test` - all building flows through
 MSBuild.
+
+**Build authority:** `Visual Studio/Envy.sln` is the authoritative build
+definition. Visual Studio 2026, MSBuild, and toolset **v145** are the
+primary path. Existing CMake files (`CMakePresets.json`, partial
+`CMakeLists.txt` trees) are auxiliary or experimental until Phase 5
+migration completes. Do not treat CMake as equivalent to the Visual Studio
+solution, do not modify the solution solely to satisfy CMake, and do not
+add new CMake changes outside a PR explicitly dedicated to CMake work.
 
 ---
 
@@ -122,9 +152,8 @@ When you take on a task you are expected to:
 1. **Update `docs/DEV_TRACKER.md`** at the start (move item from "Backlog" to
    "In progress") and at the end (move to "Done" with date + commit
    hash + brief outcome).
-2. **Push only to the designated branch**
-   (`claude/code-audit-modernization-nJcTT` for this session) with
-   `git push -u origin <branch>`.
+2. **Push only to your feature branch** (never `develop`, `main`, or
+   `legacy`) with `git push -u origin <branch>`.
 3. **Open a draft PR** if one does not exist. Match the PR template at
    `.github/pull_request_template.md`.
 4. **Tick the checkboxes** in the PR template that genuinely apply -
@@ -170,9 +199,11 @@ When you take on a task you are expected to:
   warning. Fix the warning or document why it must stay.
 - **Don't** add new dependencies to `vcpkg.json` without first
   discussing in `docs/DEV_TRACKER.md` (architectural decisions block).
-- **Don't** introduce `CMakeLists.txt` files yet. `CMakePresets.json`
-  exists as a scaffold for Phase 5; CMake migration is not in scope
-  for the current PR.
+- **Don't** expand CMake beyond its current auxiliary role. Existing
+  partial CMake files and `CMakePresets.json` are not authoritative;
+  do not add new CMake changes outside a PR explicitly dedicated to
+  CMake work, and do not modify `Visual Studio/Envy.sln` solely to
+  satisfy CMake.
 - **Don't** rewrite `MODERNIZATION.md` from scratch. Update the
   checklists, don't reflow the prose.
 - **Don't** translate translated XML files in `Languages/`. Only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,12 @@ msbuild "Visual Studio\Envy.sln" /m /p:Configuration=Release /p:Platform=x64 ^
 1. **Read** [`docs/DEV_TRACKER.md`](./docs/DEV_TRACKER.md) to see what's in flight.
 2. **Update** the tracker at start (Backlog -> In progress) and end
    (In progress -> Done with date, commit, outcome).
-3. **Push** only to the branch the session was assigned to.
+3. **Branch & merge gate.** Branch off `develop` using conventional
+   `type/short-kebab-summary` names (`feat/`, `fix/`, `docs/`, `ci/`, …);
+   never use tool- or agent-prefixed branches. You may push your own branch
+   and open **draft** PRs, but never mark ready-for-review, enable
+   auto-merge, or merge without explicit maintainer approval.
+   (See AGENTS.md section 2, rules 11-12.)
 4. **Reply to the user in the language they used in chat**, but all
    commits, comments, docs, and PR text in **English**.
 

--- a/docs/DEV_TRACKER.md
+++ b/docs/DEV_TRACKER.md
@@ -1,6 +1,6 @@
 # Envy Development Tracker
 
-_Last updated: 2026-06-07_
+_Last updated: 2026-06-14_
 
 Operational dashboard for day-to-day work. Strategic scope lives in
 [`docs/DEVELOPMENT_PLAN.md`](DEVELOPMENT_PLAN.md); technical sequencing in
@@ -25,6 +25,9 @@ Operational dashboard for day-to-day work. Strategic scope lives in
 
 ## Done (merged on `develop`)
 
+- **2026-06-14** — `docs/align-development-rules` @ `b423c07` — aligned branch
+  naming, merge gates, and build-authority rules in `AGENTS.md`, `CLAUDE.md`,
+  and governance pointer files (draft PR opened; not merged in this pass).
 - **#35** — Visual Studio 2026 (`v145`) toolset migration, CI infrastructure,
   AI rules (`AGENTS.md` and tool pointers).
 - **#43** — Lazy-load default skin; silence startup toolbar/icon debug noise.


### PR DESCRIPTION
## Summary

- Replace the obsolete session-specific branch model with `develop` as the active integration branch.
- Define functional branch naming conventions and prohibit tool-specific branch prefixes.
- Clarify the maintainer approval requirement at the ready-for-review and merge gates.
- Document Visual Studio/MSBuild as the authoritative build path while keeping CMake explicitly non-authoritative.
- Align direct governance pointers where they contradicted the canonical rules.

## Scope

- [ ] Code
- [x] Docs
- [ ] CI/Tooling
- [ ] Security
- [ ] Dependencies

## Validation

- `git diff --check`
- verified active branch-governance references
- verified no source or workflow files changed
- verified the obsolete session branch is no longer part of active instructions
- verified governance pointers remain aligned with `AGENTS.md`

## Risk Assessment

- Breaking changes: none
- Security impact: none
- Performance impact: none
- Rollback plan: revert this documentation-only commit

## Checklist

- [x] Changes are focused and reviewable
- [x] Documentation updated
- [x] No source or workflow files changed
- [ ] Changelog updated
