### PR TITLE
build(envy): use explicit path for PreBuild.cmd invocation

### DIFF
--- a/Envy/Envy.vcxproj
+++ b/Envy/Envy.vcxproj
@@ -91,7 +91,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Message>Pre-Build Dependencies...</Message>
-      <Command>PreBuild.cmd $(ConfigurationName) $(PlatformName)</Command>
+      <Command>.\PreBuild.cmd $(ConfigurationName) $(PlatformName)</Command>
     </PreBuildEvent>
     <Midl>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -155,7 +155,7 @@ if exist "$(SolutionDir)Data\Vendors.xml" copy /Y "$(SolutionDir)Data\Vendors.xm
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Message>Pre-Build Dependencies...</Message>
-      <Command>PreBuild.cmd $(ConfigurationName) $(PlatformName)</Command>
+      <Command>.\PreBuild.cmd $(ConfigurationName) $(PlatformName)</Command>
     </PreBuildEvent>
     <Midl>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -217,7 +217,7 @@ if exist "$(SolutionDir)Data\Vendors.xml" copy /Y "$(SolutionDir)Data\Vendors.xm
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Message>Pre-Build Dependencies...</Message>
-      <Command>PreBuild.cmd $(ConfigurationName) $(PlatformName)</Command>
+      <Command>.\PreBuild.cmd $(ConfigurationName) $(PlatformName)</Command>
     </PreBuildEvent>
     <Midl>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -289,7 +289,7 @@ if exist "$(SolutionDir)Data\Vendors.xml" copy /Y "$(SolutionDir)Data\Vendors.xm
     <PreBuildEvent>
       <Message>Copying DLL Services and SVN Revision...</Message>
       <Message>Pre-Build Dependencies...</Message>
-      <Command>PreBuild.cmd $(ConfigurationName) $(PlatformName)</Command>
+      <Command>.\PreBuild.cmd $(ConfigurationName) $(PlatformName)</Command>
     </PreBuildEvent>
     <Midl>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
## Summary
The `Envy` project's pre-build event invoked `PreBuild.cmd` by **bare name**. When the environment defines `NoDefaultCurrentDirectoryInExePath` (set by hardened CI runners, containers, and sandboxed agents), `cmd.exe` does not search the current directory, so the event fails with exit code **9009** before any compilation, breaking the **whole solution** build.

This prefixes the command with `.\` in all four configurations (`Debug|Win32`, `Debug|x64`, `Release|Win32`, `Release|x64`) so the script resolves explicitly, independent of that variable. The working directory stays the project dir, so the script's relative dependency copies (`..\HashLib\...`, `..\Services\...`) keep working.

## Why it matters
This is not just a local artifact: any hardened CI runner, container, or agent that sets `NoDefaultCurrentDirectoryInExePath` breaks at the same point. The fix makes the build reproducible off the maintainer's machine.

## Verification
Reproduced locally with VS 2026 (MSVC **14.51**, toolset **v145**), MFC, Windows 10 SDK.

- **Before:** with `NoDefaultCurrentDirectoryInExePath=1`, the full `Release|x64` solution build fails immediately at the `Envy` pre-build — `error MSB3073` / exit 9009.
- **After:** same hardened environment, the full `Release|x64` solution build completes with **0 errors**; `.\PreBuild.cmd` runs and copies dependency DLLs; `Envy.exe` (9.9 MB) and `TorrentEnvy.exe` are produced.

## Scope
- Touches only `Envy/Envy.vcxproj` (4 `<PreBuildEvent>` commands). No code, no behavior change.
- No other project uses a bare-name script invocation (verified across all `.vcxproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
