### PR TITLE
ci(warnings): add first-party compiler-warning baseline ratchet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,6 +187,26 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Check first-party warning baseline
+        # Reuses the build-x64-Release.warnings.log emitted by the build step
+        # above (no extra build). Only the x64 Release leg gates warnings, to
+        # avoid duplicate noise across the matrix. The check ignores SDK/MFC
+        # header warnings and vendored Services/ code; it fails only on a NEW
+        # warning in first-party source.
+        #
+        # Advisory for now (continue-on-error) until one green run confirms the
+        # committed baseline matches this runner's MSVC. To promote it to a
+        # gate: remove continue-on-error here and the "Build x64 Release"
+        # context already required in .github/settings.yml will enforce it.
+        if: ${{ success() && matrix.platform == 'x64' && matrix.configuration == 'Release' }}
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          ./Repository/Warnings/WarningBaseline.ps1 `
+            -Mode check `
+            -LogPath build-x64-Release.warnings.log
+          exit $LASTEXITCODE
+
       - name: Surface build errors to step summary and PR comment
         if: failure() && github.event_name == 'pull_request'
         shell: pwsh

--- a/Repository/Warnings/README.md
+++ b/Repository/Warnings/README.md
@@ -1,0 +1,48 @@
+# First-party warning baseline
+
+A *ratchet* that stops new compiler warnings from creeping into code we own,
+without forcing us to fix the existing backlog first.
+
+## Why
+
+The Envy core builds with `/Wall`, which produces thousands of warnings — but
+the overwhelming majority are fired **inside the Windows SDK, MFC and STL
+headers** that we include, not in our own source. A clean full-solution
+`Release|x64` build shows only a handful of warnings located in first-party
+`.cpp`/`.h` files. Those are the ones worth guarding.
+
+`WarningBaseline.ps1` extracts the warnings whose **location** is a first-party
+source file, ignoring:
+
+- anything outside the repository (SDK / MSVC / MFC headers),
+- vendored third-party trees under `Services/`,
+- the `Plugins/PluginWizard/` templates.
+
+Each warning is keyed as `<repo-relative-path>|<code>` (line/column dropped so
+the baseline does not churn when code moves). Because system-header warnings
+are excluded, the baseline is stable across MSVC point releases and CI runners.
+
+## Files
+
+- `WarningBaseline.ps1` — `-Mode generate` writes the baseline; `-Mode check`
+  fails (exit 1) if a fresh build log contains a first-party warning not in it.
+- `warnings-baseline.txt` — the committed accepted set.
+
+## CI
+
+`.github/workflows/build.yml` runs `-Mode check` on the `x64 Release` leg,
+reusing `build-x64-Release.warnings.log` from the build step (no extra build).
+It is **advisory** (`continue-on-error: true`) until one green run confirms the
+baseline matches the runner's MSVC, then it can be promoted to a hard gate.
+
+## Regenerating (ratchet down)
+
+When warnings are fixed — or new accepted ones are introduced deliberately —
+refresh the baseline from a clean build and commit the diff:
+
+```pwsh
+msbuild "Visual Studio\Envy.sln" /m /t:Rebuild /p:Configuration=Release /p:Platform=x64 `
+  /p:PlatformToolset=v145 /p:WindowsTargetPlatformVersion=10.0 `
+  /flp:"logfile=build-x64-Release.warnings.log;warningsonly;verbosity=normal;encoding=UTF-8"
+pwsh Repository/Warnings/WarningBaseline.ps1 -Mode generate -LogPath build-x64-Release.warnings.log
+```

--- a/Repository/Warnings/WarningBaseline.ps1
+++ b/Repository/Warnings/WarningBaseline.ps1
@@ -1,0 +1,157 @@
+<#
+.SYNOPSIS
+    Freeze the current compiler-warning debt as a baseline and fail CI only
+    on NEW first-party warnings (a "ratchet").
+
+.DESCRIPTION
+    The Envy core still emits thousands of /Wall-level warnings. Treating
+    warnings as errors wholesale is not yet possible, but we can stop the
+    bleeding: capture the accepted set once, then reject any pull request
+    that introduces a warning not already in that set.
+
+    A warning is keyed by "<repo-relative-path>|<code>" (e.g.
+    "envy/buffer.cpp|C5027"). Line and column numbers are deliberately
+    dropped so the baseline does not churn every time code moves.
+
+    Only first-party code is tracked. Warnings coming from outside the
+    repository (Windows SDK / MSVC headers), from vendored third-party
+    trees under Services/, and from the PluginWizard templates are ignored
+    because we do not own that code; it is migrated/handled separately
+    (vcpkg, Phase 3).
+
+.PARAMETER Mode
+    generate -> (re)write the baseline file from the given log(s).
+    check    -> compare the given log(s) against the baseline; exit 1 if any
+                new first-party warning is found.
+
+.PARAMETER LogPath
+    One or more MSBuild log files containing warning lines. Accepts the
+    output of /flp:...;warningsonly as well as a full normal-verbosity log.
+
+.PARAMETER BaselinePath
+    Path to the baseline file (default: alongside this script).
+
+.PARAMETER RepoRoot
+    Repository root used to make paths relative. Defaults to the git root
+    of this script, so it works identically on a dev box and on CI runners
+    where the absolute workspace path differs.
+
+.EXAMPLE
+    pwsh WarningBaseline.ps1 -Mode generate -LogPath build-x64-Release.warnings.log
+.EXAMPLE
+    pwsh WarningBaseline.ps1 -Mode check -LogPath build-x64-Release.warnings.log
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][ValidateSet('generate', 'check')]
+    [string]$Mode,
+    [Parameter(Mandatory)][string[]]$LogPath,
+    [string]$BaselinePath = (Join-Path $PSScriptRoot 'warnings-baseline.txt'),
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepoRoot) {
+    $RepoRoot = (& git -C $PSScriptRoot rev-parse --show-toplevel 2>$null)
+    if (-not $RepoRoot) { $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path }
+}
+$RepoRoot = ($RepoRoot -replace '\\', '/').TrimEnd('/').ToLowerInvariant()
+
+# "[N>]<path>(line[,col]): warning Cxxxx: ..."  (compiler warnings with a file)
+# The optional "N>" is the MSBuild node/project prefix emitted by parallel
+# builds at normal verbosity; strip it so it does not pollute the path.
+$rx = [regex]'^\s*(?:\d+>)?\s*(?<path>.+?)\((?<line>\d+)(?:,\d+)?\)\s*:\s*warning\s+(?<code>C\d{3,5})\s*:'
+
+function Get-Entries {
+    param([string[]]$Logs)
+    $set = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($log in $Logs) {
+        if (-not (Test-Path -LiteralPath $log)) {
+            Write-Warning "Log not found, skipping: $log"; continue
+        }
+        foreach ($line in [System.IO.File]::ReadLines((Resolve-Path -LiteralPath $log))) {
+            $m = $rx.Match($line)
+            if (-not $m.Success) { continue }
+            $p = ($m.Groups['path'].Value -replace '\\', '/').Trim().ToLowerInvariant()
+
+            # Make repo-relative; anything that is not under the repo root is
+            # external (SDK/MSVC) and is not our concern.
+            if ($p.StartsWith($RepoRoot + '/')) {
+                $rel = $p.Substring($RepoRoot.Length + 1)
+            }
+            elseif ($p -match '^[a-z]:/' -or $p.StartsWith('//')) {
+                continue  # absolute path outside the repo
+            }
+            else {
+                $rel = $p  # already relative
+            }
+
+            # Skip code we do not own / do not gate on.
+            if ($rel -like 'services/*') { continue }
+            if ($rel -like 'plugins/pluginwizard/*') { continue }
+
+            [void]$set.Add(("{0}|{1}" -f $rel, $m.Groups['code'].Value))
+        }
+    }
+    return $set
+}
+
+function Read-Baseline {
+    param([string]$Path)
+    $set = [System.Collections.Generic.HashSet[string]]::new()
+    if (Test-Path -LiteralPath $Path) {
+        foreach ($line in [System.IO.File]::ReadLines((Resolve-Path -LiteralPath $Path))) {
+            # Entries are already canonical (lower-case path, upper-case code)
+            # as written by generate mode; preserve them verbatim so the code
+            # casing matches Get-Entries.
+            $t = $line.Trim()
+            if ($t -and -not $t.StartsWith('#')) { [void]$set.Add($t) }
+        }
+    }
+    return $set
+}
+
+$current = Get-Entries -Logs $LogPath
+$sorted = @($current) | Sort-Object
+
+if ($Mode -eq 'generate') {
+    $header = @(
+        '# Envy first-party compiler-warning baseline.',
+        '# Format: <repo-relative-path>|<warning-code>  (one per line, sorted).',
+        '# Line/column numbers are intentionally omitted to avoid churn.',
+        '# Excludes Services/ (vendored) and Plugins/PluginWizard/ (templates).',
+        '# Regenerate: pwsh Repository/Warnings/WarningBaseline.ps1 -Mode generate \',
+        '#   -LogPath build-x64-Release.warnings.log',
+        ('# Entries: {0}' -f $sorted.Count),
+        ''
+    )
+    [System.IO.File]::WriteAllLines($BaselinePath, ($header + $sorted), [System.Text.UTF8Encoding]::new($false))
+    Write-Host "Wrote baseline: $BaselinePath ($($sorted.Count) entries)"
+    exit 0
+}
+
+# check mode
+$baseline = Read-Baseline -Path $BaselinePath
+if ($baseline.Count -eq 0) {
+    Write-Error "Baseline is empty or missing: $BaselinePath"
+    exit 2
+}
+
+$new = @($sorted | Where-Object { -not $baseline.Contains($_) })
+$fixed = @($baseline | Where-Object { -not $current.Contains($_) })
+
+Write-Host "First-party warnings now: $($current.Count)  |  baseline: $($baseline.Count)"
+if ($fixed.Count -gt 0) {
+    Write-Host "Good news: $($fixed.Count) baselined warning(s) no longer present. Consider regenerating the baseline to ratchet down."
+}
+
+if ($new.Count -gt 0) {
+    Write-Host ""
+    Write-Host "::error::$($new.Count) NEW first-party warning(s) introduced (not in baseline):"
+    foreach ($n in ($new | Sort-Object)) { Write-Host "  + $n" }
+    exit 1
+}
+
+Write-Host "No new first-party warnings. OK."
+exit 0

--- a/Repository/Warnings/warnings-baseline.txt
+++ b/Repository/Warnings/warnings-baseline.txt
@@ -1,0 +1,12 @@
+# Envy first-party compiler-warning baseline.
+# Format: <repo-relative-path>|<warning-code>  (one per line, sorted).
+# Line/column numbers are intentionally omitted to avoid churn.
+# Excludes Services/ (vendored) and Plugins/PluginWizard/ (templates).
+# Regenerate: pwsh Repository/Warnings/WarningBaseline.ps1 -Mode generate \
+#   -LogPath build-x64-Release.warnings.log
+# Entries: 4
+
+envy/strings.cpp|C5033
+hashlib/tigertree.cpp|C5033
+hashlib/tigertree.cpp|C5038
+plugins/swfplugin/swfreader.cpp|C5033

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -2,7 +2,8 @@
 
 > **LIVING DOCUMENT** — Must be updated after every meaningful change (feature, architectural decision, scope change, blocker resolution).
 
-- **Last Updated:** 2026-05-27
+- **Last Updated:** 2026-06-22
+- **Changelog Entry:** 2026-06-22 — Added a first-party compiler-warning baseline ratchet (`Repository/Warnings/`). A clean `Release|x64` build emits ~8.2k warnings, but only 4 are located in first-party source (3× C5033 `register`, 1× C5038 init-order); the rest fire inside SDK/MFC/STL headers under `/Wall`. CI now checks the baseline on the x64 Release leg (advisory until a green run confirms parity with the runner's MSVC).
 - **Changelog Entry:** 2026-05-27 — Documented linear-history workflow for `develop`: squash/rebase merges only, `git pull --ff-only`, feature-branch rebase commands; aligned `.github/settings.yml` with GitHub merge settings.
 - **Changelog Entry:** 2026-05-17 — Improved CodeQL C# analysis precision by introducing a dedicated manual-build workflow and documenting legacy FictionBookReader build blockers plus minimal .NET Framework 4.8 retarget path.
 - **Changelog Entry:** 2026-05-15 — Synced repository hygiene status for `develop`: documented branch state, CI gate maturity, Dependabot labels requirement, and dependency register status (`docs/DEPENDENCIES.md` exists but remains an incomplete seed).


### PR DESCRIPTION
## Summary
Adds a **first-party compiler-warning ratchet**: freeze the warnings we already accept and fail CI only on *new* ones in code we own — without having to fix the backlog first.

## The key finding
A clean `Release|x64` solution build emits **~8,289 warnings**, but only **4 are located in first-party source**:

```
envy/strings.cpp|C5033            # 'register' is no longer a storage class
hashlib/tigertree.cpp|C5033
hashlib/tigertree.cpp|C5038       # member init order
plugins/swfplugin/swfreader.cpp|C5033
```

The other **~8,180** fire **inside Windows SDK / MFC / STL headers** that Envy includes, because the core builds with `/Wall`. We can't fix those and shouldn't gate on them. So the "thousands of warnings" headline is mostly system-header noise; the real first-party debt is tiny.

## What's added
| File | Role |
|---|---|
| `Repository/Warnings/WarningBaseline.ps1` | `generate` writes the baseline; `check` exits 1 on any new first-party warning. Keys each as `path|code` (line/column dropped → no churn). Ignores SDK/MFC headers, vendored `Services/`, and `Plugins/PluginWizard/`. |
| `Repository/Warnings/warnings-baseline.txt` | The committed accepted set (4 entries). |
| `Repository/Warnings/README.md` | Rationale + regeneration steps. |
| `.github/workflows/build.yml` | Runs `check` on the **x64 Release** leg, reusing `build-x64-Release.warnings.log` (no extra build). |

## Why it's robust
Because system-header warnings are excluded, the baseline is **stable across MSVC point releases and runners** — first-party `register`/init-order warnings are deterministic. This avoids the classic cross-environment flakiness of warning baselines.

## Rollout
The CI step is **advisory** (`continue-on-error: true`) until one green run confirms the committed baseline matches the runner's MSVC. Promoting it to a hard gate is then a one-line change (remove `continue-on-error`); the `Build x64 Release` context already required in `.github/settings.yml` (PR #64) then enforces it.

## Validation (local, VS 2026 / MSVC 14.51 / v145)
- `check` against a clean log → exit 0 ("No new first-party warnings").
- `check` with an injected `envy/download.cpp|C4244` → exit 1, flags **only** that new entry.

This is the prerequisite for a later `/permissive-` + `/WX` hardening pass (`MODERNIZATION.md` Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
