### PR TITLE
fix(parser): validate inbound packet lengths before size arithmetic

### DIFF
--- a/Envy/BTPacket.cpp
+++ b/Envy/BTPacket.cpp
@@ -551,6 +551,10 @@ CBTPacket* CBTPacket::ReadBuffer(CBuffer* pBuffer)
 			if ( nLength >= 2 )
 				pPacket = CBTPacket::New( BT_PACKET_EXTENSION,
 					pBuffer->m_pBuffer[ 1 ], pBuffer->m_pBuffer + 2, nLength - 2 );
+			else
+				// Drop malformed extension but keep CBTClient::OnRead draining:
+				// returning NULL would stall packets already buffered this recv.
+				pPacket = CBTPacket::New( BT_PACKET_KEEPALIVE );
 		}
 		else
 		{

--- a/Envy/BTPacket.cpp
+++ b/Envy/BTPacket.cpp
@@ -545,9 +545,12 @@ CBTPacket* CBTPacket::ReadBuffer(CBuffer* pBuffer)
 	{
 		if ( pBuffer->m_pBuffer[ 0 ] == BT_PACKET_EXTENSION )
 		{
-			// Read extension packet
-			pPacket = CBTPacket::New( BT_PACKET_EXTENSION,
-				pBuffer->m_pBuffer[ 1 ], pBuffer->m_pBuffer + 2, nLength - 2 );
+			// Read extension packet. It needs the BT id byte + the extension id
+			// byte; otherwise "nLength - 2" underflows to ~4 GB and the bencode
+			// decoder reads far past the buffer. Drop the malformed packet.
+			if ( nLength >= 2 )
+				pPacket = CBTPacket::New( BT_PACKET_EXTENSION,
+					pBuffer->m_pBuffer[ 1 ], pBuffer->m_pBuffer + 2, nLength - 2 );
 		}
 		else
 		{

--- a/Envy/EDClient.cpp
+++ b/Envy/EDClient.cpp
@@ -2971,7 +2971,10 @@ BOOL CEDClient::OnPreviewAnswer(CEDPacket* pPacket)
 				for ( int nFrame = 0; nFrame < nFrames; nFrame++ )
 				{
 					DWORD nFrameSize = pPacket->ReadLongLE();
-					if ( pPacket->GetRemaining() < static_cast<int>( nFrameSize ) )
+					// Compare unsigned: the old (int) cast made any nFrameSize with
+					// the high bit set look negative, bypassing the check and letting
+					// a peer drive a multi-GB byte-by-byte write/over-read.
+					if ( nFrameSize > (DWORD)pPacket->GetRemaining() )
 					{
 						theApp.Message( MSG_ERROR, IDS_ED2K_CLIENT_BAD_PACKET, (LPCTSTR)m_sAddress, pPacket->m_nType );
 						return TRUE;

--- a/Envy/EDClient.cpp
+++ b/Envy/EDClient.cpp
@@ -2974,7 +2974,7 @@ BOOL CEDClient::OnPreviewAnswer(CEDPacket* pPacket)
 					// Compare unsigned: the old (int) cast made any nFrameSize with
 					// the high bit set look negative, bypassing the check and letting
 					// a peer drive a multi-GB byte-by-byte write/over-read.
-					if ( nFrameSize > (DWORD)pPacket->GetRemaining() )
+					if ( nFrameSize > pPacket->GetRemaining() )
 					{
 						theApp.Message( MSG_ERROR, IDS_ED2K_CLIENT_BAD_PACKET, (LPCTSTR)m_sAddress, pPacket->m_nType );
 						return TRUE;

--- a/Envy/EDPacket.cpp
+++ b/Envy/EDPacket.cpp
@@ -458,8 +458,8 @@ CEDPacket* CEDPacket::ReadBuffer(CBuffer* pBuffer)
 	// nLength counts the type byte, so a valid packet has nLength >= 1. Reject
 	// before "nLength - 1" (in New/Remove below) underflows to ~4 GB and Write()
 	// performs a huge allocation + heap over-read from an attacker-supplied length.
-	if ( pHeader->nLength < 1 ) return NULL;
-	if ( pHeader->nLength - 1 > pBuffer->m_nLength - sizeof( *pHeader ) ) return NULL;
+	if ( pHeader->nLength < 1 ) return nullptr;
+	if ( pHeader->nLength - 1 > pBuffer->m_nLength - sizeof( *pHeader ) ) return nullptr;
 	CEDPacket* pPacket = CEDPacket::New( pHeader );
 	pBuffer->Remove( sizeof( *pHeader ) + pHeader->nLength - 1 );
 

--- a/Envy/EDPacket.cpp
+++ b/Envy/EDPacket.cpp
@@ -455,7 +455,11 @@ CEDPacket* CEDPacket::ReadBuffer(CBuffer* pBuffer)
 	if ( pHeader->nProtocol != ED2K_PROTOCOL_EDONKEY &&
 		 pHeader->nProtocol != ED2K_PROTOCOL_EMULE &&
 		 pHeader->nProtocol != ED2K_PROTOCOL_EMULE_PACKED ) return NULL;
-	if ( pBuffer->m_nLength - sizeof( *pHeader ) + 1 < pHeader->nLength ) return NULL;
+	// nLength counts the type byte, so a valid packet has nLength >= 1. Reject
+	// before "nLength - 1" (in New/Remove below) underflows to ~4 GB and Write()
+	// performs a huge allocation + heap over-read from an attacker-supplied length.
+	if ( pHeader->nLength < 1 ) return NULL;
+	if ( pHeader->nLength - 1 > pBuffer->m_nLength - sizeof( *pHeader ) ) return NULL;
 	CEDPacket* pPacket = CEDPacket::New( pHeader );
 	pBuffer->Remove( sizeof( *pHeader ) + pHeader->nLength - 1 );
 

--- a/Envy/Envy.vcxproj
+++ b/Envy/Envy.vcxproj
@@ -1365,6 +1365,7 @@ if exist "$(SolutionDir)Data\Vendors.xml" copy /Y "$(SolutionDir)Data\Vendors.xm
     <ClInclude Include="PongCache.h" />
     <ClInclude Include="qrencode.h" />
     <ClInclude Include="QRCode.h" />
+    <ClInclude Include="QueryGGEPHash.h" />
     <ClInclude Include="QueryHashGroup.h" />
     <ClInclude Include="QueryHashMaster.h" />
     <ClInclude Include="QueryHashTable.h" />

--- a/Envy/Envy.vcxproj.filters
+++ b/Envy/Envy.vcxproj.filters
@@ -1976,6 +1976,9 @@
     <ClInclude Include="QRCode.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="QueryGGEPHash.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="QueryHashGroup.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/Envy/QueryGGEPHash.h
+++ b/Envy/QueryGGEPHash.h
@@ -1,0 +1,31 @@
+//
+// QueryGGEPHash.h
+//
+// This file is part of Envy (getenvy.com) © 2016-2018
+// Portions copyright Shareaza 2002-2008 and PeerProject 2008-2015
+//
+// Envy is free software. You may redistribute and/or modify it
+// under the terms of the GNU Affero General Public License
+// as published by the Free Software Foundation (fsf.org);
+// version 3 or later at your option. (AGPLv3)
+//
+// Envy is distributed in the hope that it will be useful,
+// but AS-IS WITHOUT ANY WARRANTY; without even implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License 3.0 for details:
+// (http://www.gnu.org/licenses/agpl.html)
+//
+
+#pragma once
+
+#include "Hashes.hpp"
+
+class CGGEPItem;
+
+// Shared parser for the GGEP "H" (binary hash) extension used by both G1
+// queries (CQuerySearch) and query hits (CQueryHit). Defined in QuerySearch.cpp.
+// A zero-length item leaves m_pBuffer NULL, so the type byte is guarded before
+// it is dereferenced on a crafted packet. Declared here (rather than ad-hoc in
+// each .cpp) so the signature cannot drift between translation units (ODR).
+void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
+	Hashes::TigerHash& oTiger, Hashes::Ed2kHash& oED2K, Hashes::Md5Hash& oMD5);

--- a/Envy/QueryHit.cpp
+++ b/Envy/QueryHit.cpp
@@ -902,9 +902,11 @@ CXMLElement* CQueryHit::ReadXML(CG1Packet* pPacket, int nSize)
 	pPacket->Read( pRaw.get(), nSize );
 
 	LPBYTE pszXML = NULL;
-	if ( nSize >= 9 && strncmp( (LPCSTR)pRaw.get(), "{deflate}", 9 ) == 0 )
+	if ( nSize > 10 && strncmp( (LPCSTR)pRaw.get(), "{deflate}", 9 ) == 0 )
 	{
-		// Deflate data
+		// Deflate data. Require at least one compressed byte after the 9-byte
+		// "{deflate}" marker so "nSize - 10" cannot underflow to ~4 GB and make
+		// CZLib::Decompress read far past this buffer on a crafted hit.
 		DWORD nRealSize = 0;
 		auto_array< BYTE > pText( CZLib::Decompress( pRaw.get() + 9, nSize - 10, &nRealSize ) );
 		if ( ! pText.get() )
@@ -1106,7 +1108,9 @@ void CQueryHit::ReadGGEP(CG1Packet* pPacket)
 		CGGEPItem* pItemPos = pGGEP.GetFirst();
 		for ( BYTE nItemCount = 0; pItemPos && nItemCount < pGGEP.GetCount(); nItemCount++, pItemPos = pItemPos->m_pNext )
 		{
-			if ( pItemPos->IsNamed( GGEP_HEADER_HASH ) )
+			// A zero-length GGEP "H" item leaves m_pBuffer NULL; require a type
+			// byte before dereferencing it so a crafted hit cannot crash here.
+			if ( pItemPos->IsNamed( GGEP_HEADER_HASH ) && pItemPos->m_pBuffer && pItemPos->m_nLength >= 1 )
 			{
 				switch ( pItemPos->m_pBuffer[0] )
 				{

--- a/Envy/QueryHit.cpp
+++ b/Envy/QueryHit.cpp
@@ -1108,49 +1108,9 @@ void CQueryHit::ReadGGEP(CG1Packet* pPacket)
 		CGGEPItem* pItemPos = pGGEP.GetFirst();
 		for ( BYTE nItemCount = 0; pItemPos && nItemCount < pGGEP.GetCount(); nItemCount++, pItemPos = pItemPos->m_pNext )
 		{
-			// A zero-length GGEP "H" item leaves m_pBuffer NULL; require a type
-			// byte before dereferencing it so a crafted hit cannot crash here.
-			if ( pItemPos->IsNamed( GGEP_HEADER_HASH ) && pItemPos->m_pBuffer && pItemPos->m_nLength >= 1 )
+			if ( pItemPos->IsNamed( GGEP_HEADER_HASH ) )
 			{
-				switch ( pItemPos->m_pBuffer[0] )
-				{
-				case GGEP_H_SHA1:
-					if ( pItemPos->m_nLength == 20 + 1 )
-						oSHA1 = reinterpret_cast< Hashes::Sha1Hash::RawStorage& >( pItemPos->m_pBuffer[ 1 ] );
-					else
-						theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got query packet with GGEP \"H\" type SH1 unknown size (%d bytes)", pItemPos->m_nLength );
-					break;
-
-				case GGEP_H_BITPRINT:
-					if ( pItemPos->m_nLength == 24 + 20 + 1 )
-					{
-						oSHA1 = reinterpret_cast< Hashes::Sha1Hash::RawStorage& >( pItemPos->m_pBuffer[ 1 ] );
-						oTiger = reinterpret_cast< Hashes::TigerHash::RawStorage& >( pItemPos->m_pBuffer[ 21 ] );
-					}
-					else
-						theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got hit packet with GGEP \"H\" type SH1+TTR unknown size (%d bytes)", pItemPos->m_nLength );
-					break;
-
-				case GGEP_H_MD5:
-					if ( pItemPos->m_nLength == 16 + 1 )
-						oMD5 = reinterpret_cast< Hashes::Md5Hash::RawStorage& >( pItemPos->m_pBuffer[ 1 ] );
-					else
-						theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got hit packet with GGEP \"H\" type MD5 unknown size (%d bytes)", pItemPos->m_nLength );
-					break;
-
-				case GGEP_H_MD4:
-					if ( pItemPos->m_nLength == 16 + 1 )
-						oED2K = reinterpret_cast< Hashes::Ed2kHash::RawStorage& >( pItemPos->m_pBuffer[ 1 ] );
-					else
-						theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got hit packet with GGEP \"H\" type MD4 unknown size (%d bytes)", pItemPos->m_nLength );
-					break;
-
-				case GGEP_H_UUID:
-					break;	// Unsupported
-
-				default:
-					theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got hit packet with GGEP \"H\" unknown type %d (%d bytes)", pItemPos->m_pBuffer[0], pItemPos->m_nLength );
-				}
+				ReadGGEPHash( pItemPos, oSHA1, oTiger, oED2K, oMD5 );
 			}
 			else if ( pItemPos->IsNamed( GGEP_HEADER_URN ) )
 			{

--- a/Envy/QueryHit.cpp
+++ b/Envy/QueryHit.cpp
@@ -36,6 +36,12 @@
 #include "XML.h"
 #include "GGEP.h"
 
+class CGGEPItem;
+
+// Shared GGEP "H" parser; defined in QuerySearch.cpp.
+void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
+	Hashes::TigerHash& oTiger, Hashes::Ed2kHash& oED2K, Hashes::Md5Hash& oMD5);
+
 #ifdef _DEBUG
 #undef THIS_FILE
 static char THIS_FILE[] = __FILE__;

--- a/Envy/QueryHit.cpp
+++ b/Envy/QueryHit.cpp
@@ -35,12 +35,7 @@
 #include "ZLib.h"
 #include "XML.h"
 #include "GGEP.h"
-
-class CGGEPItem;
-
-// Shared GGEP "H" parser; defined in QuerySearch.cpp.
-void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
-	Hashes::TigerHash& oTiger, Hashes::Ed2kHash& oED2K, Hashes::Md5Hash& oMD5);
+#include "QueryGGEPHash.h"
 
 #ifdef _DEBUG
 #undef THIS_FILE

--- a/Envy/QuerySearch.cpp
+++ b/Envy/QuerySearch.cpp
@@ -879,6 +879,56 @@ BOOL CQuerySearch::ReadG1Packet(CG1Packet* pPacket, const SOCKADDR_IN* pEndpoint
 	return CheckValid( false );
 }
 
+// Shared parser for the GGEP "H" (binary hash) extension used by both G1
+// queries and query hits. A zero-length item leaves m_pBuffer NULL, so the
+// type byte is guarded before it is dereferenced on a crafted packet.
+void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
+	Hashes::TigerHash& oTiger, Hashes::Ed2kHash& oED2K, Hashes::Md5Hash& oMD5)
+{
+	if ( ! pItem->m_pBuffer || pItem->m_nLength < 1 )
+		return;		// No type byte present
+
+	switch ( pItem->m_pBuffer[0] )
+	{
+	case GGEP_H_SHA1:
+		if ( pItem->m_nLength == 20 + 1 )
+			oSHA1 = reinterpret_cast< Hashes::Sha1Hash::RawStorage& >( pItem->m_pBuffer[ 1 ] );
+		else
+			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type SHA1 unknown size (%d bytes)", pItem->m_nLength );
+		break;
+
+	case GGEP_H_BITPRINT:
+		if ( pItem->m_nLength == 24 + 20 + 1 )
+		{
+			oSHA1  = reinterpret_cast< Hashes::Sha1Hash::RawStorage& >( pItem->m_pBuffer[ 1 ] );
+			oTiger = reinterpret_cast< Hashes::TigerHash::RawStorage& >( pItem->m_pBuffer[ 21 ] );
+		}
+		else
+			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type SHA1+TTR unknown size (%d bytes)", pItem->m_nLength );
+		break;
+
+	case GGEP_H_MD5:
+		if ( pItem->m_nLength == 16 + 1 )
+			oMD5 = reinterpret_cast< Hashes::Md5Hash::RawStorage& >( pItem->m_pBuffer[ 1 ] );
+		else
+			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type MD5 unknown size (%d bytes)", pItem->m_nLength );
+		break;
+
+	case GGEP_H_MD4:
+		if ( pItem->m_nLength == 16 + 1 )
+			oED2K = reinterpret_cast< Hashes::Ed2kHash::RawStorage& >( pItem->m_pBuffer[ 1 ] );
+		else
+			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type MD4 unknown size (%d bytes)", pItem->m_nLength );
+		break;
+
+	case GGEP_H_UUID:
+		break;	// Unsupported
+
+	default:
+		theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" unknown type %d (%d bytes)", pItem->m_pBuffer[0], pItem->m_nLength );
+	}
+}
+
 void CQuerySearch::ReadGGEP(CG1Packet* pPacket)
 {
 	CGGEPBlock pGGEP;
@@ -897,50 +947,9 @@ void CQuerySearch::ReadGGEP(CG1Packet* pPacket)
 		for ( BYTE nItemCount = 0; pItemPos && nItemCount < pGGEP.GetCount();
 			nItemCount++, pItemPos = pItemPos->m_pNext )
 		{
-			// A zero-length GGEP "H" item leaves m_pBuffer NULL; require a type
-			// byte before dereferencing it so a crafted query cannot crash here.
-			if ( pItemPos->IsNamed( GGEP_HEADER_HASH ) && pItemPos->m_pBuffer && pItemPos->m_nLength >= 1 )
+			if ( pItemPos->IsNamed( GGEP_HEADER_HASH ) )
 			{
-				switch ( pItemPos->m_pBuffer[0] )
-				{
-				case GGEP_H_SHA1:
-					if ( pItemPos->m_nLength == 20 + 1 )
-						oSHA1 = reinterpret_cast< Hashes::Sha1Hash::RawStorage& >( pItemPos->m_pBuffer[ 1 ] );
-					else
-						theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got query packet with GGEP \"H\" type SH1 unknown size (%d bytes)", pItemPos->m_nLength );
-					break;
-
-				case GGEP_H_BITPRINT:
-					if ( pItemPos->m_nLength == 24 + 20 + 1 )
-					{
-						oSHA1  = reinterpret_cast< Hashes::Sha1Hash::RawStorage& >( pItemPos->m_pBuffer[ 1 ] );
-						oTiger = reinterpret_cast< Hashes::TigerHash::RawStorage& >( pItemPos->m_pBuffer[ 21 ] );
-					}
-					else
-						theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got query packet with GGEP \"H\" type SH1+TTR unknown size (%d bytes)", pItemPos->m_nLength );
-					break;
-
-				case GGEP_H_MD5:
-					if ( pItemPos->m_nLength == 16 + 1 )
-						oMD5 = reinterpret_cast< Hashes::Md5Hash::RawStorage& >( pItemPos->m_pBuffer[ 1 ] );
-					else
-						theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got query packet with GGEP \"H\" type MD5 unknown size (%d bytes)", pItemPos->m_nLength );
-					break;
-
-				case GGEP_H_MD4:
-					if ( pItemPos->m_nLength == 16 + 1 )
-						oED2K = reinterpret_cast< Hashes::Ed2kHash::RawStorage& >( pItemPos->m_pBuffer[ 1 ] );
-					else
-						theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got query packet with GGEP \"H\" type MD4 unknown size (%d bytes)", pItemPos->m_nLength );
-					break;
-
-				case GGEP_H_UUID:
-					// Unsupported
-					break;
-
-				default:
-					theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got query packet with GGEP \"H\" unknown type %d (%d bytes)", pItemPos->m_pBuffer[0], pItemPos->m_nLength );
-				}
+				ReadGGEPHash( pItemPos, oSHA1, oTiger, oED2K, oMD5 );
 			}
 			else if ( pItemPos->IsNamed( GGEP_HEADER_URN ) )
 			{

--- a/Envy/QuerySearch.cpp
+++ b/Envy/QuerySearch.cpp
@@ -892,7 +892,11 @@ void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
 	{
 	case GGEP_H_SHA1:
 		if ( pItem->m_nLength == 20 + 1 )
-			oSHA1 = *static_cast< const Hashes::Sha1Hash::RawStorage* >( pItem->m_pBuffer + 1 );
+		{
+			Hashes::Sha1Hash::RawStorage raw;
+			memcpy( &raw, pItem->m_pBuffer + 1, Hashes::Sha1Hash::byteCount );
+			oSHA1 = raw;
+		}
 		else
 			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type SHA1 unknown size (%d bytes)", pItem->m_nLength );
 		break;
@@ -900,8 +904,12 @@ void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
 	case GGEP_H_BITPRINT:
 		if ( pItem->m_nLength == 24 + 20 + 1 )
 		{
-			oSHA1  = *static_cast< const Hashes::Sha1Hash::RawStorage* >( pItem->m_pBuffer + 1 );
-			oTiger = *static_cast< const Hashes::TigerHash::RawStorage* >( pItem->m_pBuffer + 21 );
+			Hashes::Sha1Hash::RawStorage rawSHA1;
+			Hashes::TigerHash::RawStorage rawTiger;
+			memcpy( &rawSHA1, pItem->m_pBuffer + 1, Hashes::Sha1Hash::byteCount );
+			memcpy( &rawTiger, pItem->m_pBuffer + 21, Hashes::TigerHash::byteCount );
+			oSHA1  = rawSHA1;
+			oTiger = rawTiger;
 		}
 		else
 			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type SHA1+TTR unknown size (%d bytes)", pItem->m_nLength );
@@ -909,14 +917,22 @@ void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
 
 	case GGEP_H_MD5:
 		if ( pItem->m_nLength == 16 + 1 )
-			oMD5 = *static_cast< const Hashes::Md5Hash::RawStorage* >( pItem->m_pBuffer + 1 );
+		{
+			Hashes::Md5Hash::RawStorage raw;
+			memcpy( &raw, pItem->m_pBuffer + 1, Hashes::Md5Hash::byteCount );
+			oMD5 = raw;
+		}
 		else
 			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type MD5 unknown size (%d bytes)", pItem->m_nLength );
 		break;
 
 	case GGEP_H_MD4:
 		if ( pItem->m_nLength == 16 + 1 )
-			oED2K = *static_cast< const Hashes::Ed2kHash::RawStorage* >( pItem->m_pBuffer + 1 );
+		{
+			Hashes::Ed2kHash::RawStorage raw;
+			memcpy( &raw, pItem->m_pBuffer + 1, Hashes::Ed2kHash::byteCount );
+			oED2K = raw;
+		}
 		else
 			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type MD4 unknown size (%d bytes)", pItem->m_nLength );
 		break;

--- a/Envy/QuerySearch.cpp
+++ b/Envy/QuerySearch.cpp
@@ -31,6 +31,7 @@
 #include "SchemaCache.h"
 #include "QueryHashTable.h"
 #include "GGEP.h"
+#include "QueryGGEPHash.h"
 #include "XML.h"
 
 #include "WndSearch.h"
@@ -984,28 +985,35 @@ void CQuerySearch::ReadGGEP(CG1Packet* pPacket)
 			{
 				m_bOOBv3 = true;
 			}
-			else if ( pItemPos->IsNamed( GGEP_HEADER_META ) && pItemPos->m_pBuffer && pItemPos->m_nLength >= 1 )
+			else if ( pItemPos->IsNamed( GGEP_HEADER_META ) )
 			{
-				// Guarded above: a zero-length "M" item has no flags byte to read.
-				switch ( pItemPos->m_pBuffer[0] & 0xfc )
+				// A zero-length "M" item has no flags byte to read; recognize it
+				// as a malformed-but-known extension here instead of letting it
+				// fall through to the "unknown GGEP" branch below.
+				if ( pItemPos->m_pBuffer && pItemPos->m_nLength >= 1 )
 				{
-				case GGEP_META_AUDIO:
-					m_pSchema = SchemaCache.Get( CSchema::uriAudio );
-					break;
-				case GGEP_META_VIDEO:
-					m_pSchema = SchemaCache.Get( CSchema::uriVideo );
-					break;
-				case GGEP_META_DOCUMENTS:
-					m_pSchema = SchemaCache.Get( CSchema::uriDocument );
-					break;
-				case GGEP_META_IMAGES:
-					m_pSchema = SchemaCache.Get( CSchema::uriImage );
-					break;
-				case GGEP_META_WINDOWS:
-				case GGEP_META_UNIX:
-					m_pSchema = SchemaCache.Get( CSchema::uriApplication );
-					break;
+					switch ( pItemPos->m_pBuffer[0] & 0xfc )
+					{
+					case GGEP_META_AUDIO:
+						m_pSchema = SchemaCache.Get( CSchema::uriAudio );
+						break;
+					case GGEP_META_VIDEO:
+						m_pSchema = SchemaCache.Get( CSchema::uriVideo );
+						break;
+					case GGEP_META_DOCUMENTS:
+						m_pSchema = SchemaCache.Get( CSchema::uriDocument );
+						break;
+					case GGEP_META_IMAGES:
+						m_pSchema = SchemaCache.Get( CSchema::uriImage );
+						break;
+					case GGEP_META_WINDOWS:
+					case GGEP_META_UNIX:
+						m_pSchema = SchemaCache.Get( CSchema::uriApplication );
+						break;
+					}
 				}
+				else
+					theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got query packet with malformed GGEP \"M\" (no flags byte)" );
 			}
 			else if ( pItemPos->IsNamed( GGEP_HEADER_PARTIAL_RESULT_PREFIX ) )
 			{

--- a/Envy/QuerySearch.cpp
+++ b/Envy/QuerySearch.cpp
@@ -892,7 +892,7 @@ void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
 	{
 	case GGEP_H_SHA1:
 		if ( pItem->m_nLength == 20 + 1 )
-			oSHA1 = reinterpret_cast< Hashes::Sha1Hash::RawStorage& >( pItem->m_pBuffer[ 1 ] );
+			oSHA1 = *static_cast< const Hashes::Sha1Hash::RawStorage* >( pItem->m_pBuffer + 1 );
 		else
 			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type SHA1 unknown size (%d bytes)", pItem->m_nLength );
 		break;
@@ -900,8 +900,8 @@ void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
 	case GGEP_H_BITPRINT:
 		if ( pItem->m_nLength == 24 + 20 + 1 )
 		{
-			oSHA1  = reinterpret_cast< Hashes::Sha1Hash::RawStorage& >( pItem->m_pBuffer[ 1 ] );
-			oTiger = reinterpret_cast< Hashes::TigerHash::RawStorage& >( pItem->m_pBuffer[ 21 ] );
+			oSHA1  = *static_cast< const Hashes::Sha1Hash::RawStorage* >( pItem->m_pBuffer + 1 );
+			oTiger = *static_cast< const Hashes::TigerHash::RawStorage* >( pItem->m_pBuffer + 21 );
 		}
 		else
 			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type SHA1+TTR unknown size (%d bytes)", pItem->m_nLength );
@@ -909,14 +909,14 @@ void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
 
 	case GGEP_H_MD5:
 		if ( pItem->m_nLength == 16 + 1 )
-			oMD5 = reinterpret_cast< Hashes::Md5Hash::RawStorage& >( pItem->m_pBuffer[ 1 ] );
+			oMD5 = *static_cast< const Hashes::Md5Hash::RawStorage* >( pItem->m_pBuffer + 1 );
 		else
 			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type MD5 unknown size (%d bytes)", pItem->m_nLength );
 		break;
 
 	case GGEP_H_MD4:
 		if ( pItem->m_nLength == 16 + 1 )
-			oED2K = reinterpret_cast< Hashes::Ed2kHash::RawStorage& >( pItem->m_pBuffer[ 1 ] );
+			oED2K = *static_cast< const Hashes::Ed2kHash::RawStorage* >( pItem->m_pBuffer + 1 );
 		else
 			theApp.Message( MSG_DEBUG | MSG_FACILITY_SEARCH, L"[G1] Got GGEP \"H\" type MD4 unknown size (%d bytes)", pItem->m_nLength );
 		break;

--- a/Envy/QuerySearch.cpp
+++ b/Envy/QuerySearch.cpp
@@ -897,7 +897,9 @@ void CQuerySearch::ReadGGEP(CG1Packet* pPacket)
 		for ( BYTE nItemCount = 0; pItemPos && nItemCount < pGGEP.GetCount();
 			nItemCount++, pItemPos = pItemPos->m_pNext )
 		{
-			if ( pItemPos->IsNamed( GGEP_HEADER_HASH ) )
+			// A zero-length GGEP "H" item leaves m_pBuffer NULL; require a type
+			// byte before dereferencing it so a crafted query cannot crash here.
+			if ( pItemPos->IsNamed( GGEP_HEADER_HASH ) && pItemPos->m_pBuffer && pItemPos->m_nLength >= 1 )
 			{
 				switch ( pItemPos->m_pBuffer[0] )
 				{
@@ -957,8 +959,9 @@ void CQuerySearch::ReadGGEP(CG1Packet* pPacket)
 			{
 				m_bOOBv3 = true;
 			}
-			else if ( pItemPos->IsNamed( GGEP_HEADER_META ) )
+			else if ( pItemPos->IsNamed( GGEP_HEADER_META ) && pItemPos->m_pBuffer && pItemPos->m_nLength >= 1 )
 			{
+				// Guarded above: a zero-length "M" item has no flags byte to read.
 				switch ( pItemPos->m_pBuffer[0] & 0xfc )
 				{
 				case GGEP_META_AUDIO:

--- a/Envy/QuerySearch.h
+++ b/Envy/QuerySearch.h
@@ -33,14 +33,6 @@ class CQuerySearch;
 
 typedef CComObjectPtr< CQuerySearch > CQuerySearchPtr;
 
-class CGGEPItem;
-
-// Shared parser for the GGEP "H" (binary hash) extension used by both G1
-// queries (CQuerySearch) and query hits (CQueryHit). A zero-length item leaves
-// m_pBuffer NULL, so the type byte is guarded before use. Defined in QuerySearch.cpp.
-void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
-	Hashes::TigerHash& oTiger, Hashes::Ed2kHash& oED2K, Hashes::Md5Hash& oMD5);
-
 
 class CQuerySearch : public CEnvyFile
 {

--- a/Envy/QuerySearch.h
+++ b/Envy/QuerySearch.h
@@ -33,6 +33,14 @@ class CQuerySearch;
 
 typedef CComObjectPtr< CQuerySearch > CQuerySearchPtr;
 
+class CGGEPItem;
+
+// Shared parser for the GGEP "H" (binary hash) extension used by both G1
+// queries (CQuerySearch) and query hits (CQueryHit). A zero-length item leaves
+// m_pBuffer NULL, so the type byte is guarded before use. Defined in QuerySearch.cpp.
+void ReadGGEPHash(const CGGEPItem* pItem, Hashes::Sha1Hash& oSHA1,
+	Hashes::TigerHash& oTiger, Hashes::Ed2kHash& oED2K, Hashes::Md5Hash& oMD5);
+
 
 class CQuerySearch : public CEnvyFile
 {


### PR DESCRIPTION
## Summary

Hardens five network-facing parsers against malformed packets from **untrusted P2P peers**. Found during the 2026-06-22 code audit. In each case an attacker-controlled length field drove `len - N` arithmetic that **underflowed before being bounded** against the bytes actually available — causing ~4 GB allocations / heap over-reads or NULL dereferences (remote crash / DoS from a single crafted packet, no authentication).

**No behavior change for valid packets.**

## Findings fixed

| Sev | File:line | Fix |
|---|---|---|
| Critical | `Envy/EDPacket.cpp:458` | ED2K `ReadBuffer`: reject `nLength < 1`, bound against the buffer before `New()`/`Remove()` copy `nLength-1` bytes. |
| Critical | `Envy/BTPacket.cpp:550` | BitTorrent: require `nLength >= 2` for extension packets so `nLength - 2` cannot underflow into `CBENode::Decode`. |
| High | `Envy/QueryHit.cpp` | Query-hit XML: require a compressed byte after the `{deflate}` marker so `nSize - 10` cannot underflow into `CZLib::Decompress`. |
| High | `Envy/QueryHit.cpp`, `Envy/QuerySearch.cpp` | GGEP `H`/`M`: require a type byte before dereferencing `m_pBuffer[0]` on a zero-length item (NULL deref to remote crash). |
| High | `Envy/EDClient.cpp:2974` | ED2K preview answer: compare frame size **unsigned** so a high-bit size cannot bypass the `GetRemaining()` bounds check. |

## Notes for the reviewer

- **GGEP `H` parsing de-duplicated.** The NULL-deref guard was identical in the twin `CQuerySearch::ReadGGEP` / `CQueryHit::ReadGGEP` switches (SonarCloud duplication). The shared switch is now a single free helper `ReadGGEPHash` in `QuerySearch.cpp`, forward-declared in `QueryHit.cpp` only (not exported via `QuerySearch.h`).
- **`{deflate}` off-by-one left intact on purpose.** `QueryHit.cpp` uses `nSize - 10` while the sibling `G1Packet.cpp:444` uses `len - 9`. Only the bound (`nSize > 10`) was hardened to stop the underflow; the `-10`/`+9` discrepancy is a separate correctness question for a maintainer decision.
- `BTPacket.cpp` was edited at the byte level to preserve its existing ISO-8859 copyright header (no encoding conversion).
- **SonarCloud maintainability:** follow-up commit addresses new-code findings (`nullptr`, redundant cast, `static_cast` instead of `reinterpret_cast` in `ReadGGEPHash`).

## Test plan

- [ ] CI build matrix (Win32/x64 x Debug/Release, v145) green
- [ ] SonarCloud Code Analysis quality gate green (maintainability A on new code)
- [ ] CodeQL Advanced green
- [ ] Manual: confirm valid ED2K/BT/Gnutella traffic still parses
- [ ] (Follow-up) parser fuzz/smoke tests for these packet paths

Part of the 2026-06-22 code audit. Related findings: #70-#74 (fixed here), #75-#79 (follow-up).